### PR TITLE
added support for armv7l (p.e. Raspberry Pi2/3, [cpu without SSE2])

### DIFF
--- a/philosopherstone-qt_windows_linux_i686_SSE2_and_optimized_for_generic_armv7l.pro
+++ b/philosopherstone-qt_windows_linux_i686_SSE2_and_optimized_for_generic_armv7l.pro
@@ -1,0 +1,471 @@
+TEMPLATE = app
+TARGET = philosopherstone-qt
+VERSION = 0.7.5
+QT += core gui network
+
+# WARNING hardcoded SSL-PATHes, change them to your PATHes but other pathes dit not work for me (because of my broken SSL-installation or these hardcoded SSL-pathes somewhere else?)
+OPENSSL_LIB_PATH = /usr/local/ssl/lib
+OPENSSL_INCLUDE_PATH = /usr/local/ssl/include/openssl
+
+# OPENSSL_LIB_PATH = /usr/lib/arm-linux-gnueabihf
+# OPENSSL_INCLUDE_PATH = /usr/include
+
+# If you get error: "bitcoinrpc.cpp:(.text+0x3bb8): undefined reference to `SSLv23_method'" 
+# or similar ssl/tls related error when compiling/linking 'qrc_bitcoin.o'
+# definig ssl libs as SUBLIBS in order to link ssl-libs BEFORE system-libs 
+# but this seems not to work in this *.pro file!?!?, 
+# instead try 'make SUBLIBS=-L/usr/local/ssl/lib' for compiling
+#SUBLIBS += $$join(OPENSSL_LIB_PATH,,-L,)
+#SUBLIBS += -lssl
+
+# WARNING hardcoded DB4.8-PATHes, change them to your PATHes
+BDB_LIB_PATH = /usr/local/BerkeleyDB.4.8/lib/
+BDB_LIB_SUFFIX = -4.8
+BDB_INCLUDE_PATH = /usr/local/BerkeleyDB.4.8/include/
+
+INCLUDEPATH += src src/json src/qt
+DEFINES += QT_GUI BOOST_THREAD_USE_LIB BOOST_SPIRIT_THREADSAFE BOOST_THREAD_PROVIDES_GENERIC_SHARED_MUTEX_ON_WIN __NO_SYSTEM_INCLUDES
+CONFIG += no_include_pwd
+CONFIG += thread
+CONFIG += static
+greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+
+# THE FOLLOWING SECTION WAS NOT TESTED ON WINDOWS-SYSTEM, if errors occure remove "windows: " at beginnung of lines
+windows: BOOST_LIB_SUFFIX=-mgw71-mt-s-1_64
+windows: BOOST_INCLUDE_PATH=D:/deps/x64/boost_1_64_0
+windows: BOOST_LIB_PATH=D:/deps/x64/boost_1_64_0/stage/lib
+windows: BDB_INCLUDE_PATH=D:/deps/x64/db-6.2.32/build_unix
+windows: BDB_LIB_PATH=D:/deps/x64/db-6.2.32/build_unix
+windows: OPENSSL_INCLUDE_PATH=D:/deps/x64/openssl-1.0.2l/include
+windows: OPENSSL_LIB_PATH=D:/deps/x64/openssl-1.0.2l
+windows: QRENCODE_INCLUDE_PATH=D:/deps/x64/qrencode-3.4.4
+windows: QRENCODE_LIB_PATH=D:/deps/x64/qrencode-3.4.4/.libs
+
+
+OBJECTS_DIR = build
+MOC_DIR = build
+UI_DIR = build
+
+# use: qmake "RELEASE=1"
+contains(RELEASE, 1) {
+    # Mac: compile for maximum compatibility (10.5, 32-bit)
+    macx:QMAKE_CXXFLAGS += -mmacosx-version-min=10.5 -arch x86_64 -isysroot /Developer/SDKs/MacOSX10.5.sdk
+
+    !windows:!macx {
+        # Linux: static link
+        LIBS += -Wl,-Bstatic
+    }
+}
+
+!win32 {
+# for extra security against potential buffer overflows: enable GCCs Stack Smashing Protection
+QMAKE_CXXFLAGS *= -fstack-protector-all --param ssp-buffer-size=1
+QMAKE_LFLAGS *= -fstack-protector-all --param ssp-buffer-size=1
+# We need to exclude this for Windows cross compile with MinGW 4.2.x, as it will result in a non-working executable!
+# This can be enabled for Windows, when we switch to MinGW >= 4.4.x.
+}
+# for extra security on Windows: enable ASLR and DEP via GCC linker flags
+win32:QMAKE_LFLAGS *= -Wl,--dynamicbase -Wl,--nxcompat
+# on Windows: enable GCC large address aware linker flag
+win32:QMAKE_LFLAGS *= -Wl,-static
+
+# use: qmake "USE_QRCODE=1"
+# libqrencode (http://fukuchi.org/works/qrencode/index.en.html) must be installed for support
+contains(USE_QRCODE, 1) {
+    message(Building with QRCode support)
+    DEFINES += USE_QRCODE
+    LIBS += -lqrencode -lpthread
+}
+
+# use: qmake "USE_UPNP=1" ( enabled by default; default)
+#  or: qmake "USE_UPNP=0" (disabled by default)
+#  or: qmake "USE_UPNP=-" (not supported)
+# miniupnpc (http://miniupnp.free.fr/files/) must be installed for support
+contains(USE_UPNP, -) {
+    message(Building without UPNP support)
+} else {
+    message(Building with UPNP support)
+    count(USE_UPNP, 0) {
+        USE_UPNP=1
+    }
+    DEFINES += USE_UPNP=$$USE_UPNP STATICLIB
+    INCLUDEPATH += $$MINIUPNPC_INCLUDE_PATH
+    LIBS += $$join(MINIUPNPC_LIB_PATH,,-L,) -lminiupnpc
+    win32:LIBS += -liphlpapi
+}
+
+# use: qmake "USE_DBUS=1" or qmake "USE_DBUS=0"
+linux:count(USE_DBUS, 0) {
+    USE_DBUS=1
+}
+contains(USE_DBUS, 1) {
+    message(Building with DBUS (Freedesktop notifications) support)
+    DEFINES += USE_DBUS
+    QT += dbus
+}
+
+contains(BITCOIN_NEED_QT_PLUGINS, 1) {
+    DEFINES += BITCOIN_NEED_QT_PLUGINS
+    QTPLUGIN += qcncodecs qjpcodecs qtwcodecs qkrcodecs qtaccessiblewidgets
+}
+
+INCLUDEPATH += src/leveldb/include src/leveldb/helpers
+LIBS += $$PWD/src/leveldb/libleveldb.a $$PWD/src/leveldb/libmemenv.a
+SOURCES += src/txdb-leveldb.cpp
+!win32 {
+    # we use QMAKE_CXXFLAGS_RELEASE even without RELEASE=1 because we use RELEASE to indicate linking preferences not -O preferences
+    genleveldb.commands = cd $$PWD/src/leveldb && CC=$$QMAKE_CC CXX=$$QMAKE_CXX $(MAKE) OPT=\"$$QMAKE_CXXFLAGS $$QMAKE_CXXFLAGS_RELEASE\" libleveldb.a libmemenv.a
+} else {
+    # make an educated guess about what the ranlib command is called
+    isEmpty(QMAKE_RANLIB) {
+        QMAKE_RANLIB = $$replace(QMAKE_STRIP, strip, ranlib)
+    }
+    LIBS += -lshlwapi
+    #genleveldb.commands = cd $$PWD/src/leveldb && CC=$$QMAKE_CC CXX=$$QMAKE_CXX TARGET_OS=OS_WINDOWS_CROSSCOMPILE $(MAKE) OPT=\"$$QMAKE_CXXFLAGS $$QMAKE_CXXFLAGS_RELEASE\" libleveldb.a libmemenv.a && $$QMAKE_RANLIB $$PWD/src/leveldb/libleveldb.a && $$QMAKE_RANLIB $$PWD/src/leveldb/libmemenv.a
+}
+genleveldb.target = $$PWD/src/leveldb/libleveldb.a
+genleveldb.depends = FORCE
+PRE_TARGETDEPS += $$PWD/src/leveldb/libleveldb.a
+QMAKE_EXTRA_TARGETS += genleveldb
+# Gross ugly hack that depends on qmake internals, unfortunately there is no other way to do it.
+QMAKE_CLEAN += $$PWD/src/leveldb/libleveldb.a; cd $$PWD/src/leveldb ; $(MAKE) clean
+
+
+# regenerate src/build.h
+!windows|contains(USE_BUILD_INFO, 1) {
+    genbuild.depends = FORCE
+    genbuild.commands = cd $$PWD; /bin/sh share/genbuild.sh $$OUT_PWD/build/build.h
+    genbuild.target = $$OUT_PWD/build/build.h
+    PRE_TARGETDEPS += $$OUT_PWD/build/build.h
+    QMAKE_EXTRA_TARGETS += genbuild
+    DEFINES += HAVE_BUILD_INFO
+}
+
+# If we have an arm device, we can't use sse2, so define as thumb
+# Because of scrypt_mine.cpp, we also have to add a compile
+#     flag that states we *really* don't have SSE
+# Otherwise, assume sse2 exists
+!equals($$QMAKE_HOST.arch, armv7l) {
+    message(FOUND host = $$QMAKE_HOST.arch)
+
+QMAKE_CXXFLAGS += -mthumb -DNOSSE
+QMAKE_CFLAGS +=   -mthumb -DNOSSE
+
+# for  Raspberry PI 2 (not tested my be you could add '-Ofast' and '-ftree-vectorize -ffast-math', too)
+# QMAKE_CXXFLAGS += -mthumb -DNOSSE  -march=armv7-a -mtune=cortex-a8 
+# QMAKE_CFLAGS +=   -mthumb -DNOSSE  -march=armv7-a -mtune=cortex-a8
+
+# for Raspberry PI 3    
+# QMAKE_CXXFLAGS += -mthumb -DNOSSE -Ofast -march=armv8-a+crc -mtune=cortex-a53 -mcpu=cortex-a53 -ftree-vectorize -ffast-math
+# QMAKE_CFLAGS +=   -mthumb -DNOSSE -Ofast -march=armv8-a+crc -mtune=cortex-a53 -mcpu=cortex-a53 -ftree-vectorize -ffast-math
+}
+else {
+contains(USE_O3, 1) {
+    message(Building O3 optimization flag)
+    QMAKE_CXXFLAGS_RELEASE -= -O2
+    QMAKE_CFLAGS_RELEASE -= -O2
+    QMAKE_CXXFLAGS += -O3
+    QMAKE_CFLAGS += -O3
+}
+
+    QMAKE_CXXFLAGS += -msse2
+    QMAKE_CFLAGS += -msse2
+}
+#endif
+
+QMAKE_CXXFLAGS_WARN_ON = -fdiagnostics-show-option -Wall -Wextra -Wno-ignored-qualifiers -Wformat -Wformat-security -Wno-unused-parameter -Wstack-protector
+
+# Input
+DEPENDPATH += src src/json src/qt
+HEADERS += \
+    src/addrman.h \
+    src/alert.h \
+    src/allocators.h \
+    src/base58.h \
+    src/bignum.h \
+    src/bitcoinrpc.h \
+    src/checkpoints.h \
+    src/clientversion.h \
+    src/coincontrol.h \
+    src/compat.h \
+    src/crypter.h \
+    src/db.h \
+    src/init.h \
+    src/irc.h \
+    src/json/json_spirit.h \
+    src/json/json_spirit_error_position.h \
+    src/json/json_spirit_reader.h \
+    src/json/json_spirit_reader_template.h \
+    src/json/json_spirit_stream_reader.h \
+    src/json/json_spirit_utils.h \
+    src/json/json_spirit_value.h \
+    src/json/json_spirit_writer.h \
+    src/json/json_spirit_writer_template.h \
+    src/kernel.h \
+    src/key.h \
+    src/keystore.h \
+    src/main.h \
+    src/miner.h \
+    src/mruset.h \
+    src/net.h \
+    src/netbase.h \
+    src/pbkdf2.h \
+    src/protocol.h \
+    src/qt/aboutdialog.h \
+    src/qt/addressbookpage.h \
+    src/qt/addresstablemodel.h \
+    src/qt/askpassphrasedialog.h \
+    src/qt/bitcoinaddressvalidator.h \
+    src/qt/bitcoinamountfield.h \
+    src/qt/bitcoingui.h \
+    src/qt/bitcoinunits.h \
+    src/qt/clientmodel.h \
+    src/qt/coincontroldialog.h \
+    src/qt/coincontroltreewidget.h \
+    src/qt/csvmodelwriter.h \
+    src/qt/editaddressdialog.h \
+    src/qt/guiconstants.h \
+    src/qt/guiutil.h \
+    src/qt/monitoreddatamapper.h \
+    src/qt/notificator.h \
+    src/qt/optionsdialog.h \
+    src/qt/optionsmodel.h \
+    src/qt/overviewpage.h \
+    src/qt/qcustomplot.h \
+    src/qt/qtipcserver.h \
+    src/qt/qvalidatedlineedit.h \
+    src/qt/qvaluecombobox.h \
+    src/qt/rpcconsole.h \
+    src/qt/sendcoinsdialog.h \
+    src/qt/sendcoinsentry.h \
+    src/qt/signverifymessagedialog.h \
+    src/qt/transactiondesc.h \
+    src/qt/transactiondescdialog.h \
+    src/qt/transactionfilterproxy.h \
+    src/qt/transactionrecord.h \
+    src/qt/transactiontablemodel.h \
+    src/qt/transactionview.h \
+    src/qt/walletmodel.h \
+    src/script.h \
+    src/scrypt_mine.h \
+    src/serialize.h \
+    src/strlcpy.h \
+    src/sync.h \
+    src/ui_interface.h \
+    src/uint256.h \
+    src/util.h \
+    src/version.h \
+    src/wallet.h \
+    src/walletdb.h 
+
+SOURCES += \
+    src/addrman.cpp \
+    src/alert.cpp \
+    src/bitcoinrpc.cpp \
+    src/checkpoints.cpp \
+    src/crypter.cpp \
+    src/db.cpp \
+    src/init.cpp \
+    src/irc.cpp \
+    src/kernel.cpp \
+    src/key.cpp \
+    src/keystore.cpp \
+    src/main.cpp \
+    src/miner.cpp \
+    src/net.cpp \
+    src/netbase.cpp \
+    src/noui.cpp \
+    src/pbkdf2.cpp \
+    src/protocol.cpp \
+    src/qt/aboutdialog.cpp \
+    src/qt/addressbookpage.cpp \
+    src/qt/addresstablemodel.cpp \
+    src/qt/askpassphrasedialog.cpp \
+    src/qt/bitcoin.cpp src/qt/bitcoingui.cpp \
+    src/qt/bitcoinaddressvalidator.cpp \
+    src/qt/bitcoinamountfield.cpp \
+    src/qt/bitcoinstrings.cpp \
+    src/qt/bitcoinunits.cpp \
+    src/qt/clientmodel.cpp \
+    src/qt/coincontroldialog.cpp \
+    src/qt/coincontroltreewidget.cpp \
+    src/qt/csvmodelwriter.cpp \
+    src/qt/editaddressdialog.cpp \
+    src/qt/guiutil.cpp \
+    src/qt/monitoreddatamapper.cpp \
+    src/qt/notificator.cpp \
+    src/qt/optionsdialog.cpp \
+    src/qt/optionsmodel.cpp \
+    src/qt/overviewpage.cpp \
+    src/qt/qcustomplot.cpp \
+    src/qt/qtipcserver.cpp \
+    src/qt/qvalidatedlineedit.cpp \
+    src/qt/qvaluecombobox.cpp \
+    src/qt/rpcconsole.cpp \
+    src/qt/sendcoinsdialog.cpp \
+    src/qt/sendcoinsentry.cpp \
+    src/qt/signverifymessagedialog.cpp \
+    src/qt/transactiondesc.cpp \
+    src/qt/transactiondescdialog.cpp \
+    src/qt/transactionfilterproxy.cpp \
+    src/qt/transactionrecord.cpp \
+    src/qt/transactiontablemodel.cpp \
+    src/qt/transactionview.cpp \
+    src/qt/walletmodel.cpp \
+    src/rpcblockchain.cpp \
+    src/rpcdump.cpp \
+    src/rpcmining.cpp \
+    src/rpcnet.cpp \
+    src/rpcrawtransaction.cpp \
+    src/rpcwallet.cpp \
+    src/script.cpp \
+ src/scrypt-arm.S \
+    src/scrypt_mine.cpp \
+    src/scrypt-x86.S \
+    src/scrypt-x86_64.S \
+    src/sync.cpp \
+    src/util.cpp \
+    src/version.cpp \
+    src/wallet.cpp \
+    src/walletdb.cpp
+	
+	RESOURCES += \
+    src/qt/bitcoin.qrc
+
+FORMS += \
+    src/qt/forms/aboutdialog.ui \
+    src/qt/forms/addressbookpage.ui \
+    src/qt/forms/askpassphrasedialog.ui \
+    src/qt/forms/coincontroldialog.ui \
+    src/qt/forms/editaddressdialog.ui \
+    src/qt/forms/optionsdialog.ui \
+    src/qt/forms/overviewpage.ui \
+    src/qt/forms/rpcconsole.ui \
+    src/qt/forms/sendcoinsdialog.ui \
+    src/qt/forms/sendcoinsentry.ui \
+    src/qt/forms/signverifymessagedialog.ui \
+    src/qt/forms/transactiondescdialog.ui 
+
+contains(USE_QRCODE, 1) {
+HEADERS += src/qt/qrcodedialog.h
+SOURCES += src/qt/qrcodedialog.cpp
+FORMS += src/qt/forms/qrcodedialog.ui
+}
+
+contains(BITCOIN_QT_TEST, 1) {
+SOURCES += src/qt/test/test_main.cpp \
+    src/qt/test/uritests.cpp
+HEADERS += src/qt/test/uritests.h
+DEPENDPATH += src/qt/test
+QT += testlib
+TARGET = philosopherstone-qt_test
+DEFINES += BITCOIN_QT_TEST
+}
+
+CODECFORTR = UTF-8
+
+# for lrelease/lupdate
+# also add new translations to src/qt/bitcoin.qrc under translations/
+TRANSLATIONS = $$files(src/qt/locale/bitcoin_*.ts)
+
+isEmpty(QMAKE_LRELEASE) {
+    win32:QMAKE_LRELEASE = $$[QT_INSTALL_BINS]\\lrelease.exe
+    else:QMAKE_LRELEASE = $$[QT_INSTALL_BINS]/lrelease
+}
+isEmpty(QM_DIR):QM_DIR = $$PWD/src/qt/locale
+# automatically build translations, so they can be included in resource file
+TSQM.name = lrelease ${QMAKE_FILE_IN}
+TSQM.input = TRANSLATIONS
+TSQM.output = $$QM_DIR/${QMAKE_FILE_BASE}.qm
+TSQM.commands = $$QMAKE_LRELEASE ${QMAKE_FILE_IN} -qm ${QMAKE_FILE_OUT}
+TSQM.CONFIG = no_link
+QMAKE_EXTRA_COMPILERS += TSQM
+
+# "Other files" to show in Qt Creator
+OTHER_FILES += \
+    doc/*.rst doc/*.txt doc/README README.md res/bitcoin-qt.rc src/test/*.cpp src/test/*.h src/qt/test/*.cpp src/qt/test/*.h
+
+# platform specific defaults, if not overridden on command line
+isEmpty(BOOST_LIB_SUFFIX) {
+    macx:BOOST_LIB_SUFFIX = -mt
+    windows:BOOST_LIB_SUFFIX = -mgw71-mt-s-1_57
+}
+
+isEmpty(BOOST_THREAD_LIB_SUFFIX) {
+    BOOST_THREAD_LIB_SUFFIX = $$BOOST_LIB_SUFFIX
+}
+
+isEmpty(BDB_LIB_PATH) {
+    macx:BDB_LIB_PATH = /opt/local/lib/db48
+}
+
+isEmpty(BDB_LIB_SUFFIX) {
+    macx:BDB_LIB_SUFFIX = -4.8
+}
+
+isEmpty(BDB_INCLUDE_PATH) {
+    macx:BDB_INCLUDE_PATH = /opt/local/include/db48
+}
+
+isEmpty(BOOST_LIB_PATH) {
+    macx:BOOST_LIB_PATH = /opt/local/lib
+}
+
+isEmpty(BOOST_INCLUDE_PATH) {
+    macx:BOOST_INCLUDE_PATH = /opt/local/include
+}
+
+windows:DEFINES += WIN32 WIN32_LEAN_AND_MEAN
+windows:RC_FILE = src/qt/res/bitcoin-qt.rc
+
+windows:!contains(MINGW_THREAD_BUGFIX, 0) {
+    # At least qmake's win32-g++-cross profile is missing the -lmingwthrd
+    # thread-safety flag. GCC has -mthreads to enable this, but it doesn't
+    # work with static linking. -lmingwthrd must come BEFORE -lmingw, so
+    # it is prepended to QMAKE_LIBS_QT_ENTRY.
+    # It can be turned off with MINGW_THREAD_BUGFIX=0, just in case it causes
+    # any problems on some untested qmake profile now or in the future.
+    DEFINES += _MT BOOST_THREAD_PROVIDES_GENERIC_SHARED_MUTEX_ON_WIN
+    QMAKE_LIBS_QT_ENTRY = -lmingwthrd $$QMAKE_LIBS_QT_ENTRY
+}
+
+
+
+macx:HEADERS += src/qt/macdockiconhandler.h
+macx:OBJECTIVE_SOURCES += src/qt/macdockiconhandler.mm
+macx:LIBS += -framework Foundation -framework ApplicationServices -framework AppKit
+macx:DEFINES += MAC_OSX MSG_NOSIGNAL=0
+macx:ICON = src/qt/res/icons/Philosopherstone.icns
+macx:TARGET = "philosopherstone-qt"
+macx:QMAKE_CFLAGS_THREAD += -pthread
+macx:QMAKE_LFLAGS_THREAD += -pthread
+macx:QMAKE_CXXFLAGS_THREAD += -pthread
+
+# very likely unnessesary 
+QMAKE_LIBS_QT_ENTRY = -lssl $$OPENSSL_LIB_PATH
+
+# Set libraries and includes at end, to use platform-defined defaults if not overridden
+INCLUDEPATH += $$BOOST_INCLUDE_PATH $$BDB_INCLUDE_PATH $$OPENSSL_INCLUDE_PATH $$QRENCODE_INCLUDE_PATH
+# moved ssl-libs to beginning of file for customizing more easily and for OVERRIDING platform-defined defaults
+LIBS += $$join(BOOST_LIB_PATH,,-L,) $$join(BDB_LIB_PATH,,-L,) $$join(OPENSSL_LIB_PATH,,-L,) 
+LIBS += -lssl
+LIBS += $$join(QRENCODE_LIB_PATH,,-L,)
+LIBS += -lcrypto -ldb_cxx$$BDB_LIB_SUFFIX
+# -lgdi32 has to happen after -lcrypto (see  #681)
+windows:LIBS += -lws2_32 -lshlwapi -lmswsock -lole32 -loleaut32 -luuid -lgdi32
+LIBS += -lboost_system$$BOOST_LIB_SUFFIX -lboost_filesystem$$BOOST_LIB_SUFFIX -lboost_program_options$$BOOST_LIB_SUFFIX -lboost_thread$$BOOST_THREAD_LIB_SUFFIX
+windows:LIBS += -lboost_chrono$$BOOST_LIB_SUFFIX
+
+contains(RELEASE, 1) {
+    !windows:!macx {
+        # Linux: turn dynamic linking back on for c/c++ runtime libraries
+        LIBS += -Wl,-Bdynamic
+    }
+}
+
+!windows:!macx {
+    DEFINES += LINUX
+    LIBS += -lrt -ldl
+}
+
+system($$QMAKE_LRELEASE -silent $$_PRO_FILE_)

--- a/philosopherstone-qt_windows_linux_i686_SSE2_and_optimized_for_raspberry_pi2.pro
+++ b/philosopherstone-qt_windows_linux_i686_SSE2_and_optimized_for_raspberry_pi2.pro
@@ -1,0 +1,475 @@
+TEMPLATE = app
+TARGET = philosopherstone-qt
+VERSION = 0.7.5
+QT += core gui network
+
+# WARNING hardcoded SSL-PATHes, change them to your PATHes but other pathes dit not work for me (because of my broken SSL-installation or these hardcoded SSL-pathes somewhere else?)
+OPENSSL_LIB_PATH = /usr/local/ssl/lib
+OPENSSL_INCLUDE_PATH = /usr/local/ssl/include/openssl
+
+# OPENSSL_LIB_PATH = /usr/lib/arm-linux-gnueabihf
+# OPENSSL_INCLUDE_PATH = /usr/include
+
+# If you get error: "bitcoinrpc.cpp:(.text+0x3bb8): undefined reference to `SSLv23_method'" 
+# or similar ssl/tls related error when compiling/linking 'qrc_bitcoin.o'
+# definig ssl libs as SUBLIBS in order to link ssl-libs BEFORE system-libs 
+# but this seems not to work in this *.pro file!?!?, 
+# instead try 'make SUBLIBS=-L/usr/local/ssl/lib' for compiling
+#SUBLIBS += $$join(OPENSSL_LIB_PATH,,-L,)
+#SUBLIBS += -lssl
+
+# WARNING hardcoded DB4.8-PATHes, change them to your PATHes
+BDB_LIB_PATH = /usr/local/BerkeleyDB.4.8/lib/
+BDB_LIB_SUFFIX = -4.8
+BDB_INCLUDE_PATH = /usr/local/BerkeleyDB.4.8/include/
+
+INCLUDEPATH += src src/json src/qt
+DEFINES += QT_GUI BOOST_THREAD_USE_LIB BOOST_SPIRIT_THREADSAFE BOOST_THREAD_PROVIDES_GENERIC_SHARED_MUTEX_ON_WIN __NO_SYSTEM_INCLUDES
+CONFIG += no_include_pwd
+CONFIG += thread
+CONFIG += static
+greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+
+# THE FOLLOWING SECTION WAS NOT TESTED ON WINDOWS-SYSTEM, if errors occure remove "windows: " at beginnung of lines
+windows: BOOST_LIB_SUFFIX=-mgw71-mt-s-1_64
+windows: BOOST_INCLUDE_PATH=D:/deps/x64/boost_1_64_0
+windows: BOOST_LIB_PATH=D:/deps/x64/boost_1_64_0/stage/lib
+windows: BDB_INCLUDE_PATH=D:/deps/x64/db-6.2.32/build_unix
+windows: BDB_LIB_PATH=D:/deps/x64/db-6.2.32/build_unix
+windows: OPENSSL_INCLUDE_PATH=D:/deps/x64/openssl-1.0.2l/include
+windows: OPENSSL_LIB_PATH=D:/deps/x64/openssl-1.0.2l
+windows: QRENCODE_INCLUDE_PATH=D:/deps/x64/qrencode-3.4.4
+windows: QRENCODE_LIB_PATH=D:/deps/x64/qrencode-3.4.4/.libs
+
+
+OBJECTS_DIR = build
+MOC_DIR = build
+UI_DIR = build
+
+# use: qmake "RELEASE=1"
+contains(RELEASE, 1) {
+    # Mac: compile for maximum compatibility (10.5, 32-bit)
+    macx:QMAKE_CXXFLAGS += -mmacosx-version-min=10.5 -arch x86_64 -isysroot /Developer/SDKs/MacOSX10.5.sdk
+
+    !windows:!macx {
+        # Linux: static link
+        LIBS += -Wl,-Bstatic
+    }
+}
+
+!win32 {
+# for extra security against potential buffer overflows: enable GCCs Stack Smashing Protection
+QMAKE_CXXFLAGS *= -fstack-protector-all --param ssp-buffer-size=1
+QMAKE_LFLAGS *= -fstack-protector-all --param ssp-buffer-size=1
+# We need to exclude this for Windows cross compile with MinGW 4.2.x, as it will result in a non-working executable!
+# This can be enabled for Windows, when we switch to MinGW >= 4.4.x.
+}
+# for extra security on Windows: enable ASLR and DEP via GCC linker flags
+win32:QMAKE_LFLAGS *= -Wl,--dynamicbase -Wl,--nxcompat
+# on Windows: enable GCC large address aware linker flag
+win32:QMAKE_LFLAGS *= -Wl,-static
+
+# use: qmake "USE_QRCODE=1"
+# libqrencode (http://fukuchi.org/works/qrencode/index.en.html) must be installed for support
+contains(USE_QRCODE, 1) {
+    message(Building with QRCode support)
+    DEFINES += USE_QRCODE
+    LIBS += -lqrencode -lpthread
+}
+
+# use: qmake "USE_UPNP=1" ( enabled by default; default)
+#  or: qmake "USE_UPNP=0" (disabled by default)
+#  or: qmake "USE_UPNP=-" (not supported)
+# miniupnpc (http://miniupnp.free.fr/files/) must be installed for support
+contains(USE_UPNP, -) {
+    message(Building without UPNP support)
+} else {
+    message(Building with UPNP support)
+    count(USE_UPNP, 0) {
+        USE_UPNP=1
+    }
+    DEFINES += USE_UPNP=$$USE_UPNP STATICLIB
+    INCLUDEPATH += $$MINIUPNPC_INCLUDE_PATH
+    LIBS += $$join(MINIUPNPC_LIB_PATH,,-L,) -lminiupnpc
+    win32:LIBS += -liphlpapi
+}
+
+# use: qmake "USE_DBUS=1" or qmake "USE_DBUS=0"
+linux:count(USE_DBUS, 0) {
+    USE_DBUS=1
+}
+contains(USE_DBUS, 1) {
+    message(Building with DBUS (Freedesktop notifications) support)
+    DEFINES += USE_DBUS
+    QT += dbus
+}
+
+contains(BITCOIN_NEED_QT_PLUGINS, 1) {
+    DEFINES += BITCOIN_NEED_QT_PLUGINS
+    QTPLUGIN += qcncodecs qjpcodecs qtwcodecs qkrcodecs qtaccessiblewidgets
+}
+
+INCLUDEPATH += src/leveldb/include src/leveldb/helpers
+LIBS += $$PWD/src/leveldb/libleveldb.a $$PWD/src/leveldb/libmemenv.a
+SOURCES += src/txdb-leveldb.cpp
+!win32 {
+    # we use QMAKE_CXXFLAGS_RELEASE even without RELEASE=1 because we use RELEASE to indicate linking preferences not -O preferences
+    genleveldb.commands = cd $$PWD/src/leveldb && CC=$$QMAKE_CC CXX=$$QMAKE_CXX $(MAKE) OPT=\"$$QMAKE_CXXFLAGS $$QMAKE_CXXFLAGS_RELEASE\" libleveldb.a libmemenv.a
+} else {
+    # make an educated guess about what the ranlib command is called
+    isEmpty(QMAKE_RANLIB) {
+        QMAKE_RANLIB = $$replace(QMAKE_STRIP, strip, ranlib)
+    }
+    LIBS += -lshlwapi
+    #genleveldb.commands = cd $$PWD/src/leveldb && CC=$$QMAKE_CC CXX=$$QMAKE_CXX TARGET_OS=OS_WINDOWS_CROSSCOMPILE $(MAKE) OPT=\"$$QMAKE_CXXFLAGS $$QMAKE_CXXFLAGS_RELEASE\" libleveldb.a libmemenv.a && $$QMAKE_RANLIB $$PWD/src/leveldb/libleveldb.a && $$QMAKE_RANLIB $$PWD/src/leveldb/libmemenv.a
+}
+genleveldb.target = $$PWD/src/leveldb/libleveldb.a
+genleveldb.depends = FORCE
+PRE_TARGETDEPS += $$PWD/src/leveldb/libleveldb.a
+QMAKE_EXTRA_TARGETS += genleveldb
+# Gross ugly hack that depends on qmake internals, unfortunately there is no other way to do it.
+QMAKE_CLEAN += $$PWD/src/leveldb/libleveldb.a; cd $$PWD/src/leveldb ; $(MAKE) clean
+
+
+# regenerate src/build.h
+!windows|contains(USE_BUILD_INFO, 1) {
+    genbuild.depends = FORCE
+    genbuild.commands = cd $$PWD; /bin/sh share/genbuild.sh $$OUT_PWD/build/build.h
+    genbuild.target = $$OUT_PWD/build/build.h
+    PRE_TARGETDEPS += $$OUT_PWD/build/build.h
+    QMAKE_EXTRA_TARGETS += genbuild
+    DEFINES += HAVE_BUILD_INFO
+}
+
+# If we have an arm device, we can't use sse2, so define as thumb
+# Because of scrypt_mine.cpp, we also have to add a compile
+#     flag that states we *really* don't have SSE
+# Otherwise, assume sse2 exists
+!equals($$QMAKE_HOST.arch, armv7l) {
+    message(FOUND host = $$QMAKE_HOST.arch)
+
+# QMAKE_CXXFLAGS += -mthumb -DNOSSE  -march=armv7-a -mtune=cortex-a8 
+# QMAKE_CFLAGS +=   -mthumb -DNOSSE  -march=armv7-a -mtune=cortex-a8
+
+# for  Raspberry PI 2 (not tested my be you could add '-Ofast' and '-ftree-vectorize -ffast-math', too)
+QMAKE_CXXFLAGS += -mthumb -DNOSSE  -march=armv7-a -mtune=cortex-a8 
+QMAKE_CFLAGS +=   -mthumb -DNOSSE  -march=armv7-a -mtune=cortex-a8
+
+# for Raspberry PI 3    
+# QMAKE_CXXFLAGS += -mthumb -DNOSSE -Ofast -march=armv8-a+crc -mtune=cortex-a53 -mcpu=cortex-a53 -ftree-vectorize -ffast-math
+# QMAKE_CFLAGS +=   -mthumb -DNOSSE -Ofast -march=armv8-a+crc -mtune=cortex-a53 -mcpu=cortex-a53 -ftree-vectorize -ffast-math
+
+
+
+
+}
+else {
+contains(USE_O3, 1) {
+    message(Building O3 optimization flag)
+    QMAKE_CXXFLAGS_RELEASE -= -O2
+    QMAKE_CFLAGS_RELEASE -= -O2
+    QMAKE_CXXFLAGS += -O3
+    QMAKE_CFLAGS += -O3
+}
+
+    QMAKE_CXXFLAGS += -msse2
+    QMAKE_CFLAGS += -msse2
+}
+#endif
+
+QMAKE_CXXFLAGS_WARN_ON = -fdiagnostics-show-option -Wall -Wextra -Wno-ignored-qualifiers -Wformat -Wformat-security -Wno-unused-parameter -Wstack-protector
+
+# Input
+DEPENDPATH += src src/json src/qt
+HEADERS += \
+    src/addrman.h \
+    src/alert.h \
+    src/allocators.h \
+    src/base58.h \
+    src/bignum.h \
+    src/bitcoinrpc.h \
+    src/checkpoints.h \
+    src/clientversion.h \
+    src/coincontrol.h \
+    src/compat.h \
+    src/crypter.h \
+    src/db.h \
+    src/init.h \
+    src/irc.h \
+    src/json/json_spirit.h \
+    src/json/json_spirit_error_position.h \
+    src/json/json_spirit_reader.h \
+    src/json/json_spirit_reader_template.h \
+    src/json/json_spirit_stream_reader.h \
+    src/json/json_spirit_utils.h \
+    src/json/json_spirit_value.h \
+    src/json/json_spirit_writer.h \
+    src/json/json_spirit_writer_template.h \
+    src/kernel.h \
+    src/key.h \
+    src/keystore.h \
+    src/main.h \
+    src/miner.h \
+    src/mruset.h \
+    src/net.h \
+    src/netbase.h \
+    src/pbkdf2.h \
+    src/protocol.h \
+    src/qt/aboutdialog.h \
+    src/qt/addressbookpage.h \
+    src/qt/addresstablemodel.h \
+    src/qt/askpassphrasedialog.h \
+    src/qt/bitcoinaddressvalidator.h \
+    src/qt/bitcoinamountfield.h \
+    src/qt/bitcoingui.h \
+    src/qt/bitcoinunits.h \
+    src/qt/clientmodel.h \
+    src/qt/coincontroldialog.h \
+    src/qt/coincontroltreewidget.h \
+    src/qt/csvmodelwriter.h \
+    src/qt/editaddressdialog.h \
+    src/qt/guiconstants.h \
+    src/qt/guiutil.h \
+    src/qt/monitoreddatamapper.h \
+    src/qt/notificator.h \
+    src/qt/optionsdialog.h \
+    src/qt/optionsmodel.h \
+    src/qt/overviewpage.h \
+    src/qt/qcustomplot.h \
+    src/qt/qtipcserver.h \
+    src/qt/qvalidatedlineedit.h \
+    src/qt/qvaluecombobox.h \
+    src/qt/rpcconsole.h \
+    src/qt/sendcoinsdialog.h \
+    src/qt/sendcoinsentry.h \
+    src/qt/signverifymessagedialog.h \
+    src/qt/transactiondesc.h \
+    src/qt/transactiondescdialog.h \
+    src/qt/transactionfilterproxy.h \
+    src/qt/transactionrecord.h \
+    src/qt/transactiontablemodel.h \
+    src/qt/transactionview.h \
+    src/qt/walletmodel.h \
+    src/script.h \
+    src/scrypt_mine.h \
+    src/serialize.h \
+    src/strlcpy.h \
+    src/sync.h \
+    src/ui_interface.h \
+    src/uint256.h \
+    src/util.h \
+    src/version.h \
+    src/wallet.h \
+    src/walletdb.h 
+
+SOURCES += \
+    src/addrman.cpp \
+    src/alert.cpp \
+    src/bitcoinrpc.cpp \
+    src/checkpoints.cpp \
+    src/crypter.cpp \
+    src/db.cpp \
+    src/init.cpp \
+    src/irc.cpp \
+    src/kernel.cpp \
+    src/key.cpp \
+    src/keystore.cpp \
+    src/main.cpp \
+    src/miner.cpp \
+    src/net.cpp \
+    src/netbase.cpp \
+    src/noui.cpp \
+    src/pbkdf2.cpp \
+    src/protocol.cpp \
+    src/qt/aboutdialog.cpp \
+    src/qt/addressbookpage.cpp \
+    src/qt/addresstablemodel.cpp \
+    src/qt/askpassphrasedialog.cpp \
+    src/qt/bitcoin.cpp src/qt/bitcoingui.cpp \
+    src/qt/bitcoinaddressvalidator.cpp \
+    src/qt/bitcoinamountfield.cpp \
+    src/qt/bitcoinstrings.cpp \
+    src/qt/bitcoinunits.cpp \
+    src/qt/clientmodel.cpp \
+    src/qt/coincontroldialog.cpp \
+    src/qt/coincontroltreewidget.cpp \
+    src/qt/csvmodelwriter.cpp \
+    src/qt/editaddressdialog.cpp \
+    src/qt/guiutil.cpp \
+    src/qt/monitoreddatamapper.cpp \
+    src/qt/notificator.cpp \
+    src/qt/optionsdialog.cpp \
+    src/qt/optionsmodel.cpp \
+    src/qt/overviewpage.cpp \
+    src/qt/qcustomplot.cpp \
+    src/qt/qtipcserver.cpp \
+    src/qt/qvalidatedlineedit.cpp \
+    src/qt/qvaluecombobox.cpp \
+    src/qt/rpcconsole.cpp \
+    src/qt/sendcoinsdialog.cpp \
+    src/qt/sendcoinsentry.cpp \
+    src/qt/signverifymessagedialog.cpp \
+    src/qt/transactiondesc.cpp \
+    src/qt/transactiondescdialog.cpp \
+    src/qt/transactionfilterproxy.cpp \
+    src/qt/transactionrecord.cpp \
+    src/qt/transactiontablemodel.cpp \
+    src/qt/transactionview.cpp \
+    src/qt/walletmodel.cpp \
+    src/rpcblockchain.cpp \
+    src/rpcdump.cpp \
+    src/rpcmining.cpp \
+    src/rpcnet.cpp \
+    src/rpcrawtransaction.cpp \
+    src/rpcwallet.cpp \
+    src/script.cpp \
+ src/scrypt-arm.S \
+    src/scrypt_mine.cpp \
+    src/scrypt-x86.S \
+    src/scrypt-x86_64.S \
+    src/sync.cpp \
+    src/util.cpp \
+    src/version.cpp \
+    src/wallet.cpp \
+    src/walletdb.cpp
+	
+	RESOURCES += \
+    src/qt/bitcoin.qrc
+
+FORMS += \
+    src/qt/forms/aboutdialog.ui \
+    src/qt/forms/addressbookpage.ui \
+    src/qt/forms/askpassphrasedialog.ui \
+    src/qt/forms/coincontroldialog.ui \
+    src/qt/forms/editaddressdialog.ui \
+    src/qt/forms/optionsdialog.ui \
+    src/qt/forms/overviewpage.ui \
+    src/qt/forms/rpcconsole.ui \
+    src/qt/forms/sendcoinsdialog.ui \
+    src/qt/forms/sendcoinsentry.ui \
+    src/qt/forms/signverifymessagedialog.ui \
+    src/qt/forms/transactiondescdialog.ui 
+
+contains(USE_QRCODE, 1) {
+HEADERS += src/qt/qrcodedialog.h
+SOURCES += src/qt/qrcodedialog.cpp
+FORMS += src/qt/forms/qrcodedialog.ui
+}
+
+contains(BITCOIN_QT_TEST, 1) {
+SOURCES += src/qt/test/test_main.cpp \
+    src/qt/test/uritests.cpp
+HEADERS += src/qt/test/uritests.h
+DEPENDPATH += src/qt/test
+QT += testlib
+TARGET = philosopherstone-qt_test
+DEFINES += BITCOIN_QT_TEST
+}
+
+CODECFORTR = UTF-8
+
+# for lrelease/lupdate
+# also add new translations to src/qt/bitcoin.qrc under translations/
+TRANSLATIONS = $$files(src/qt/locale/bitcoin_*.ts)
+
+isEmpty(QMAKE_LRELEASE) {
+    win32:QMAKE_LRELEASE = $$[QT_INSTALL_BINS]\\lrelease.exe
+    else:QMAKE_LRELEASE = $$[QT_INSTALL_BINS]/lrelease
+}
+isEmpty(QM_DIR):QM_DIR = $$PWD/src/qt/locale
+# automatically build translations, so they can be included in resource file
+TSQM.name = lrelease ${QMAKE_FILE_IN}
+TSQM.input = TRANSLATIONS
+TSQM.output = $$QM_DIR/${QMAKE_FILE_BASE}.qm
+TSQM.commands = $$QMAKE_LRELEASE ${QMAKE_FILE_IN} -qm ${QMAKE_FILE_OUT}
+TSQM.CONFIG = no_link
+QMAKE_EXTRA_COMPILERS += TSQM
+
+# "Other files" to show in Qt Creator
+OTHER_FILES += \
+    doc/*.rst doc/*.txt doc/README README.md res/bitcoin-qt.rc src/test/*.cpp src/test/*.h src/qt/test/*.cpp src/qt/test/*.h
+
+# platform specific defaults, if not overridden on command line
+isEmpty(BOOST_LIB_SUFFIX) {
+    macx:BOOST_LIB_SUFFIX = -mt
+    windows:BOOST_LIB_SUFFIX = -mgw71-mt-s-1_57
+}
+
+isEmpty(BOOST_THREAD_LIB_SUFFIX) {
+    BOOST_THREAD_LIB_SUFFIX = $$BOOST_LIB_SUFFIX
+}
+
+isEmpty(BDB_LIB_PATH) {
+    macx:BDB_LIB_PATH = /opt/local/lib/db48
+}
+
+isEmpty(BDB_LIB_SUFFIX) {
+    macx:BDB_LIB_SUFFIX = -4.8
+}
+
+isEmpty(BDB_INCLUDE_PATH) {
+    macx:BDB_INCLUDE_PATH = /opt/local/include/db48
+}
+
+isEmpty(BOOST_LIB_PATH) {
+    macx:BOOST_LIB_PATH = /opt/local/lib
+}
+
+isEmpty(BOOST_INCLUDE_PATH) {
+    macx:BOOST_INCLUDE_PATH = /opt/local/include
+}
+
+windows:DEFINES += WIN32 WIN32_LEAN_AND_MEAN
+windows:RC_FILE = src/qt/res/bitcoin-qt.rc
+
+windows:!contains(MINGW_THREAD_BUGFIX, 0) {
+    # At least qmake's win32-g++-cross profile is missing the -lmingwthrd
+    # thread-safety flag. GCC has -mthreads to enable this, but it doesn't
+    # work with static linking. -lmingwthrd must come BEFORE -lmingw, so
+    # it is prepended to QMAKE_LIBS_QT_ENTRY.
+    # It can be turned off with MINGW_THREAD_BUGFIX=0, just in case it causes
+    # any problems on some untested qmake profile now or in the future.
+    DEFINES += _MT BOOST_THREAD_PROVIDES_GENERIC_SHARED_MUTEX_ON_WIN
+    QMAKE_LIBS_QT_ENTRY = -lmingwthrd $$QMAKE_LIBS_QT_ENTRY
+}
+
+
+
+macx:HEADERS += src/qt/macdockiconhandler.h
+macx:OBJECTIVE_SOURCES += src/qt/macdockiconhandler.mm
+macx:LIBS += -framework Foundation -framework ApplicationServices -framework AppKit
+macx:DEFINES += MAC_OSX MSG_NOSIGNAL=0
+macx:ICON = src/qt/res/icons/Philosopherstone.icns
+macx:TARGET = "philosopherstone-qt"
+macx:QMAKE_CFLAGS_THREAD += -pthread
+macx:QMAKE_LFLAGS_THREAD += -pthread
+macx:QMAKE_CXXFLAGS_THREAD += -pthread
+
+# very likely unnessesary 
+QMAKE_LIBS_QT_ENTRY = -lssl $$OPENSSL_LIB_PATH
+
+# Set libraries and includes at end, to use platform-defined defaults if not overridden
+INCLUDEPATH += $$BOOST_INCLUDE_PATH $$BDB_INCLUDE_PATH $$OPENSSL_INCLUDE_PATH $$QRENCODE_INCLUDE_PATH
+# moved ssl-libs to beginning of file for customizing more easily and for OVERRIDING platform-defined defaults
+LIBS += $$join(BOOST_LIB_PATH,,-L,) $$join(BDB_LIB_PATH,,-L,) $$join(OPENSSL_LIB_PATH,,-L,) 
+LIBS += -lssl
+LIBS += $$join(QRENCODE_LIB_PATH,,-L,)
+LIBS += -lcrypto -ldb_cxx$$BDB_LIB_SUFFIX
+# -lgdi32 has to happen after -lcrypto (see  #681)
+windows:LIBS += -lws2_32 -lshlwapi -lmswsock -lole32 -loleaut32 -luuid -lgdi32
+LIBS += -lboost_system$$BOOST_LIB_SUFFIX -lboost_filesystem$$BOOST_LIB_SUFFIX -lboost_program_options$$BOOST_LIB_SUFFIX -lboost_thread$$BOOST_THREAD_LIB_SUFFIX
+windows:LIBS += -lboost_chrono$$BOOST_LIB_SUFFIX
+
+contains(RELEASE, 1) {
+    !windows:!macx {
+        # Linux: turn dynamic linking back on for c/c++ runtime libraries
+        LIBS += -Wl,-Bdynamic
+    }
+}
+
+!windows:!macx {
+    DEFINES += LINUX
+    LIBS += -lrt -ldl
+}
+
+system($$QMAKE_LRELEASE -silent $$_PRO_FILE_)

--- a/philosopherstone-qt_windows_linux_i686_SSE2_and_optimized_for_raspberry_pi3.pro
+++ b/philosopherstone-qt_windows_linux_i686_SSE2_and_optimized_for_raspberry_pi3.pro
@@ -1,0 +1,475 @@
+TEMPLATE = app
+TARGET = philosopherstone-qt
+VERSION = 0.7.5
+QT += core gui network
+
+# WARNING hardcoded SSL-PATHes, change them to your PATHes but other pathes dit not work for me (because of my broken SSL-installation or these hardcoded SSL-pathes somewhere else?)
+OPENSSL_LIB_PATH = /usr/local/ssl/lib
+OPENSSL_INCLUDE_PATH = /usr/local/ssl/include/openssl
+
+# OPENSSL_LIB_PATH = /usr/lib/arm-linux-gnueabihf
+# OPENSSL_INCLUDE_PATH = /usr/include
+
+# If you get error: "bitcoinrpc.cpp:(.text+0x3bb8): undefined reference to `SSLv23_method'" 
+# or similar ssl/tls related error when compiling/linking 'qrc_bitcoin.o'
+# definig ssl libs as SUBLIBS in order to link ssl-libs BEFORE system-libs 
+# but this seems not to work in this *.pro file!?!?, 
+# instead try 'make SUBLIBS=-L/usr/local/ssl/lib' for compiling
+#SUBLIBS += $$join(OPENSSL_LIB_PATH,,-L,)
+#SUBLIBS += -lssl
+
+# WARNING hardcoded DB4.8-PATHes, change them to your PATHes
+BDB_LIB_PATH = /usr/local/BerkeleyDB.4.8/lib/
+BDB_LIB_SUFFIX = -4.8
+BDB_INCLUDE_PATH = /usr/local/BerkeleyDB.4.8/include/
+
+INCLUDEPATH += src src/json src/qt
+DEFINES += QT_GUI BOOST_THREAD_USE_LIB BOOST_SPIRIT_THREADSAFE BOOST_THREAD_PROVIDES_GENERIC_SHARED_MUTEX_ON_WIN __NO_SYSTEM_INCLUDES
+CONFIG += no_include_pwd
+CONFIG += thread
+CONFIG += static
+greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+
+# THE FOLLOWING SECTION WAS NOT TESTED ON WINDOWS-SYSTEM, if errors occure remove "windows: " at beginnung of lines
+windows: BOOST_LIB_SUFFIX=-mgw71-mt-s-1_64
+windows: BOOST_INCLUDE_PATH=D:/deps/x64/boost_1_64_0
+windows: BOOST_LIB_PATH=D:/deps/x64/boost_1_64_0/stage/lib
+windows: BDB_INCLUDE_PATH=D:/deps/x64/db-6.2.32/build_unix
+windows: BDB_LIB_PATH=D:/deps/x64/db-6.2.32/build_unix
+windows: OPENSSL_INCLUDE_PATH=D:/deps/x64/openssl-1.0.2l/include
+windows: OPENSSL_LIB_PATH=D:/deps/x64/openssl-1.0.2l
+windows: QRENCODE_INCLUDE_PATH=D:/deps/x64/qrencode-3.4.4
+windows: QRENCODE_LIB_PATH=D:/deps/x64/qrencode-3.4.4/.libs
+
+
+OBJECTS_DIR = build
+MOC_DIR = build
+UI_DIR = build
+
+# use: qmake "RELEASE=1"
+contains(RELEASE, 1) {
+    # Mac: compile for maximum compatibility (10.5, 32-bit)
+    macx:QMAKE_CXXFLAGS += -mmacosx-version-min=10.5 -arch x86_64 -isysroot /Developer/SDKs/MacOSX10.5.sdk
+
+    !windows:!macx {
+        # Linux: static link
+        LIBS += -Wl,-Bstatic
+    }
+}
+
+!win32 {
+# for extra security against potential buffer overflows: enable GCCs Stack Smashing Protection
+QMAKE_CXXFLAGS *= -fstack-protector-all --param ssp-buffer-size=1
+QMAKE_LFLAGS *= -fstack-protector-all --param ssp-buffer-size=1
+# We need to exclude this for Windows cross compile with MinGW 4.2.x, as it will result in a non-working executable!
+# This can be enabled for Windows, when we switch to MinGW >= 4.4.x.
+}
+# for extra security on Windows: enable ASLR and DEP via GCC linker flags
+win32:QMAKE_LFLAGS *= -Wl,--dynamicbase -Wl,--nxcompat
+# on Windows: enable GCC large address aware linker flag
+win32:QMAKE_LFLAGS *= -Wl,-static
+
+# use: qmake "USE_QRCODE=1"
+# libqrencode (http://fukuchi.org/works/qrencode/index.en.html) must be installed for support
+contains(USE_QRCODE, 1) {
+    message(Building with QRCode support)
+    DEFINES += USE_QRCODE
+    LIBS += -lqrencode -lpthread
+}
+
+# use: qmake "USE_UPNP=1" ( enabled by default; default)
+#  or: qmake "USE_UPNP=0" (disabled by default)
+#  or: qmake "USE_UPNP=-" (not supported)
+# miniupnpc (http://miniupnp.free.fr/files/) must be installed for support
+contains(USE_UPNP, -) {
+    message(Building without UPNP support)
+} else {
+    message(Building with UPNP support)
+    count(USE_UPNP, 0) {
+        USE_UPNP=1
+    }
+    DEFINES += USE_UPNP=$$USE_UPNP STATICLIB
+    INCLUDEPATH += $$MINIUPNPC_INCLUDE_PATH
+    LIBS += $$join(MINIUPNPC_LIB_PATH,,-L,) -lminiupnpc
+    win32:LIBS += -liphlpapi
+}
+
+# use: qmake "USE_DBUS=1" or qmake "USE_DBUS=0"
+linux:count(USE_DBUS, 0) {
+    USE_DBUS=1
+}
+contains(USE_DBUS, 1) {
+    message(Building with DBUS (Freedesktop notifications) support)
+    DEFINES += USE_DBUS
+    QT += dbus
+}
+
+contains(BITCOIN_NEED_QT_PLUGINS, 1) {
+    DEFINES += BITCOIN_NEED_QT_PLUGINS
+    QTPLUGIN += qcncodecs qjpcodecs qtwcodecs qkrcodecs qtaccessiblewidgets
+}
+
+INCLUDEPATH += src/leveldb/include src/leveldb/helpers
+LIBS += $$PWD/src/leveldb/libleveldb.a $$PWD/src/leveldb/libmemenv.a
+SOURCES += src/txdb-leveldb.cpp
+!win32 {
+    # we use QMAKE_CXXFLAGS_RELEASE even without RELEASE=1 because we use RELEASE to indicate linking preferences not -O preferences
+    genleveldb.commands = cd $$PWD/src/leveldb && CC=$$QMAKE_CC CXX=$$QMAKE_CXX $(MAKE) OPT=\"$$QMAKE_CXXFLAGS $$QMAKE_CXXFLAGS_RELEASE\" libleveldb.a libmemenv.a
+} else {
+    # make an educated guess about what the ranlib command is called
+    isEmpty(QMAKE_RANLIB) {
+        QMAKE_RANLIB = $$replace(QMAKE_STRIP, strip, ranlib)
+    }
+    LIBS += -lshlwapi
+    #genleveldb.commands = cd $$PWD/src/leveldb && CC=$$QMAKE_CC CXX=$$QMAKE_CXX TARGET_OS=OS_WINDOWS_CROSSCOMPILE $(MAKE) OPT=\"$$QMAKE_CXXFLAGS $$QMAKE_CXXFLAGS_RELEASE\" libleveldb.a libmemenv.a && $$QMAKE_RANLIB $$PWD/src/leveldb/libleveldb.a && $$QMAKE_RANLIB $$PWD/src/leveldb/libmemenv.a
+}
+genleveldb.target = $$PWD/src/leveldb/libleveldb.a
+genleveldb.depends = FORCE
+PRE_TARGETDEPS += $$PWD/src/leveldb/libleveldb.a
+QMAKE_EXTRA_TARGETS += genleveldb
+# Gross ugly hack that depends on qmake internals, unfortunately there is no other way to do it.
+QMAKE_CLEAN += $$PWD/src/leveldb/libleveldb.a; cd $$PWD/src/leveldb ; $(MAKE) clean
+
+
+# regenerate src/build.h
+!windows|contains(USE_BUILD_INFO, 1) {
+    genbuild.depends = FORCE
+    genbuild.commands = cd $$PWD; /bin/sh share/genbuild.sh $$OUT_PWD/build/build.h
+    genbuild.target = $$OUT_PWD/build/build.h
+    PRE_TARGETDEPS += $$OUT_PWD/build/build.h
+    QMAKE_EXTRA_TARGETS += genbuild
+    DEFINES += HAVE_BUILD_INFO
+}
+
+# If we have an arm device, we can't use sse2, so define as thumb
+# Because of scrypt_mine.cpp, we also have to add a compile
+#     flag that states we *really* don't have SSE
+# Otherwise, assume sse2 exists
+!equals($$QMAKE_HOST.arch, armv7l) {
+    message(FOUND host = $$QMAKE_HOST.arch)
+
+# QMAKE_CXXFLAGS += -mthumb -DNOSSE  -march=armv7-a -mtune=cortex-a8 
+# QMAKE_CFLAGS +=   -mthumb -DNOSSE  -march=armv7-a -mtune=cortex-a8
+
+# for  Raspberry PI 2 (not tested my be you could add '-Ofast' and '-ftree-vectorize -ffast-math', too)
+# QMAKE_CXXFLAGS += -mthumb -DNOSSE  -march=armv7-a -mtune=cortex-a8 
+# QMAKE_CFLAGS +=   -mthumb -DNOSSE  -march=armv7-a -mtune=cortex-a8
+
+# for Raspberry PI 3    
+QMAKE_CXXFLAGS += -mthumb -DNOSSE -Ofast -march=armv8-a+crc -mtune=cortex-a53 -mcpu=cortex-a53 -ftree-vectorize -ffast-math
+QMAKE_CFLAGS +=   -mthumb -DNOSSE -Ofast -march=armv8-a+crc -mtune=cortex-a53 -mcpu=cortex-a53 -ftree-vectorize -ffast-math
+
+
+
+
+}
+else {
+contains(USE_O3, 1) {
+    message(Building O3 optimization flag)
+    QMAKE_CXXFLAGS_RELEASE -= -O2
+    QMAKE_CFLAGS_RELEASE -= -O2
+    QMAKE_CXXFLAGS += -O3
+    QMAKE_CFLAGS += -O3
+}
+
+    QMAKE_CXXFLAGS += -msse2
+    QMAKE_CFLAGS += -msse2
+}
+#endif
+
+QMAKE_CXXFLAGS_WARN_ON = -fdiagnostics-show-option -Wall -Wextra -Wno-ignored-qualifiers -Wformat -Wformat-security -Wno-unused-parameter -Wstack-protector
+
+# Input
+DEPENDPATH += src src/json src/qt
+HEADERS += \
+    src/addrman.h \
+    src/alert.h \
+    src/allocators.h \
+    src/base58.h \
+    src/bignum.h \
+    src/bitcoinrpc.h \
+    src/checkpoints.h \
+    src/clientversion.h \
+    src/coincontrol.h \
+    src/compat.h \
+    src/crypter.h \
+    src/db.h \
+    src/init.h \
+    src/irc.h \
+    src/json/json_spirit.h \
+    src/json/json_spirit_error_position.h \
+    src/json/json_spirit_reader.h \
+    src/json/json_spirit_reader_template.h \
+    src/json/json_spirit_stream_reader.h \
+    src/json/json_spirit_utils.h \
+    src/json/json_spirit_value.h \
+    src/json/json_spirit_writer.h \
+    src/json/json_spirit_writer_template.h \
+    src/kernel.h \
+    src/key.h \
+    src/keystore.h \
+    src/main.h \
+    src/miner.h \
+    src/mruset.h \
+    src/net.h \
+    src/netbase.h \
+    src/pbkdf2.h \
+    src/protocol.h \
+    src/qt/aboutdialog.h \
+    src/qt/addressbookpage.h \
+    src/qt/addresstablemodel.h \
+    src/qt/askpassphrasedialog.h \
+    src/qt/bitcoinaddressvalidator.h \
+    src/qt/bitcoinamountfield.h \
+    src/qt/bitcoingui.h \
+    src/qt/bitcoinunits.h \
+    src/qt/clientmodel.h \
+    src/qt/coincontroldialog.h \
+    src/qt/coincontroltreewidget.h \
+    src/qt/csvmodelwriter.h \
+    src/qt/editaddressdialog.h \
+    src/qt/guiconstants.h \
+    src/qt/guiutil.h \
+    src/qt/monitoreddatamapper.h \
+    src/qt/notificator.h \
+    src/qt/optionsdialog.h \
+    src/qt/optionsmodel.h \
+    src/qt/overviewpage.h \
+    src/qt/qcustomplot.h \
+    src/qt/qtipcserver.h \
+    src/qt/qvalidatedlineedit.h \
+    src/qt/qvaluecombobox.h \
+    src/qt/rpcconsole.h \
+    src/qt/sendcoinsdialog.h \
+    src/qt/sendcoinsentry.h \
+    src/qt/signverifymessagedialog.h \
+    src/qt/transactiondesc.h \
+    src/qt/transactiondescdialog.h \
+    src/qt/transactionfilterproxy.h \
+    src/qt/transactionrecord.h \
+    src/qt/transactiontablemodel.h \
+    src/qt/transactionview.h \
+    src/qt/walletmodel.h \
+    src/script.h \
+    src/scrypt_mine.h \
+    src/serialize.h \
+    src/strlcpy.h \
+    src/sync.h \
+    src/ui_interface.h \
+    src/uint256.h \
+    src/util.h \
+    src/version.h \
+    src/wallet.h \
+    src/walletdb.h 
+
+SOURCES += \
+    src/addrman.cpp \
+    src/alert.cpp \
+    src/bitcoinrpc.cpp \
+    src/checkpoints.cpp \
+    src/crypter.cpp \
+    src/db.cpp \
+    src/init.cpp \
+    src/irc.cpp \
+    src/kernel.cpp \
+    src/key.cpp \
+    src/keystore.cpp \
+    src/main.cpp \
+    src/miner.cpp \
+    src/net.cpp \
+    src/netbase.cpp \
+    src/noui.cpp \
+    src/pbkdf2.cpp \
+    src/protocol.cpp \
+    src/qt/aboutdialog.cpp \
+    src/qt/addressbookpage.cpp \
+    src/qt/addresstablemodel.cpp \
+    src/qt/askpassphrasedialog.cpp \
+    src/qt/bitcoin.cpp src/qt/bitcoingui.cpp \
+    src/qt/bitcoinaddressvalidator.cpp \
+    src/qt/bitcoinamountfield.cpp \
+    src/qt/bitcoinstrings.cpp \
+    src/qt/bitcoinunits.cpp \
+    src/qt/clientmodel.cpp \
+    src/qt/coincontroldialog.cpp \
+    src/qt/coincontroltreewidget.cpp \
+    src/qt/csvmodelwriter.cpp \
+    src/qt/editaddressdialog.cpp \
+    src/qt/guiutil.cpp \
+    src/qt/monitoreddatamapper.cpp \
+    src/qt/notificator.cpp \
+    src/qt/optionsdialog.cpp \
+    src/qt/optionsmodel.cpp \
+    src/qt/overviewpage.cpp \
+    src/qt/qcustomplot.cpp \
+    src/qt/qtipcserver.cpp \
+    src/qt/qvalidatedlineedit.cpp \
+    src/qt/qvaluecombobox.cpp \
+    src/qt/rpcconsole.cpp \
+    src/qt/sendcoinsdialog.cpp \
+    src/qt/sendcoinsentry.cpp \
+    src/qt/signverifymessagedialog.cpp \
+    src/qt/transactiondesc.cpp \
+    src/qt/transactiondescdialog.cpp \
+    src/qt/transactionfilterproxy.cpp \
+    src/qt/transactionrecord.cpp \
+    src/qt/transactiontablemodel.cpp \
+    src/qt/transactionview.cpp \
+    src/qt/walletmodel.cpp \
+    src/rpcblockchain.cpp \
+    src/rpcdump.cpp \
+    src/rpcmining.cpp \
+    src/rpcnet.cpp \
+    src/rpcrawtransaction.cpp \
+    src/rpcwallet.cpp \
+    src/script.cpp \
+ src/scrypt-arm.S \
+    src/scrypt_mine.cpp \
+    src/scrypt-x86.S \
+    src/scrypt-x86_64.S \
+    src/sync.cpp \
+    src/util.cpp \
+    src/version.cpp \
+    src/wallet.cpp \
+    src/walletdb.cpp
+	
+	RESOURCES += \
+    src/qt/bitcoin.qrc
+
+FORMS += \
+    src/qt/forms/aboutdialog.ui \
+    src/qt/forms/addressbookpage.ui \
+    src/qt/forms/askpassphrasedialog.ui \
+    src/qt/forms/coincontroldialog.ui \
+    src/qt/forms/editaddressdialog.ui \
+    src/qt/forms/optionsdialog.ui \
+    src/qt/forms/overviewpage.ui \
+    src/qt/forms/rpcconsole.ui \
+    src/qt/forms/sendcoinsdialog.ui \
+    src/qt/forms/sendcoinsentry.ui \
+    src/qt/forms/signverifymessagedialog.ui \
+    src/qt/forms/transactiondescdialog.ui 
+
+contains(USE_QRCODE, 1) {
+HEADERS += src/qt/qrcodedialog.h
+SOURCES += src/qt/qrcodedialog.cpp
+FORMS += src/qt/forms/qrcodedialog.ui
+}
+
+contains(BITCOIN_QT_TEST, 1) {
+SOURCES += src/qt/test/test_main.cpp \
+    src/qt/test/uritests.cpp
+HEADERS += src/qt/test/uritests.h
+DEPENDPATH += src/qt/test
+QT += testlib
+TARGET = philosopherstone-qt_test
+DEFINES += BITCOIN_QT_TEST
+}
+
+CODECFORTR = UTF-8
+
+# for lrelease/lupdate
+# also add new translations to src/qt/bitcoin.qrc under translations/
+TRANSLATIONS = $$files(src/qt/locale/bitcoin_*.ts)
+
+isEmpty(QMAKE_LRELEASE) {
+    win32:QMAKE_LRELEASE = $$[QT_INSTALL_BINS]\\lrelease.exe
+    else:QMAKE_LRELEASE = $$[QT_INSTALL_BINS]/lrelease
+}
+isEmpty(QM_DIR):QM_DIR = $$PWD/src/qt/locale
+# automatically build translations, so they can be included in resource file
+TSQM.name = lrelease ${QMAKE_FILE_IN}
+TSQM.input = TRANSLATIONS
+TSQM.output = $$QM_DIR/${QMAKE_FILE_BASE}.qm
+TSQM.commands = $$QMAKE_LRELEASE ${QMAKE_FILE_IN} -qm ${QMAKE_FILE_OUT}
+TSQM.CONFIG = no_link
+QMAKE_EXTRA_COMPILERS += TSQM
+
+# "Other files" to show in Qt Creator
+OTHER_FILES += \
+    doc/*.rst doc/*.txt doc/README README.md res/bitcoin-qt.rc src/test/*.cpp src/test/*.h src/qt/test/*.cpp src/qt/test/*.h
+
+# platform specific defaults, if not overridden on command line
+isEmpty(BOOST_LIB_SUFFIX) {
+    macx:BOOST_LIB_SUFFIX = -mt
+    windows:BOOST_LIB_SUFFIX = -mgw71-mt-s-1_57
+}
+
+isEmpty(BOOST_THREAD_LIB_SUFFIX) {
+    BOOST_THREAD_LIB_SUFFIX = $$BOOST_LIB_SUFFIX
+}
+
+isEmpty(BDB_LIB_PATH) {
+    macx:BDB_LIB_PATH = /opt/local/lib/db48
+}
+
+isEmpty(BDB_LIB_SUFFIX) {
+    macx:BDB_LIB_SUFFIX = -4.8
+}
+
+isEmpty(BDB_INCLUDE_PATH) {
+    macx:BDB_INCLUDE_PATH = /opt/local/include/db48
+}
+
+isEmpty(BOOST_LIB_PATH) {
+    macx:BOOST_LIB_PATH = /opt/local/lib
+}
+
+isEmpty(BOOST_INCLUDE_PATH) {
+    macx:BOOST_INCLUDE_PATH = /opt/local/include
+}
+
+windows:DEFINES += WIN32 WIN32_LEAN_AND_MEAN
+windows:RC_FILE = src/qt/res/bitcoin-qt.rc
+
+windows:!contains(MINGW_THREAD_BUGFIX, 0) {
+    # At least qmake's win32-g++-cross profile is missing the -lmingwthrd
+    # thread-safety flag. GCC has -mthreads to enable this, but it doesn't
+    # work with static linking. -lmingwthrd must come BEFORE -lmingw, so
+    # it is prepended to QMAKE_LIBS_QT_ENTRY.
+    # It can be turned off with MINGW_THREAD_BUGFIX=0, just in case it causes
+    # any problems on some untested qmake profile now or in the future.
+    DEFINES += _MT BOOST_THREAD_PROVIDES_GENERIC_SHARED_MUTEX_ON_WIN
+    QMAKE_LIBS_QT_ENTRY = -lmingwthrd $$QMAKE_LIBS_QT_ENTRY
+}
+
+
+
+macx:HEADERS += src/qt/macdockiconhandler.h
+macx:OBJECTIVE_SOURCES += src/qt/macdockiconhandler.mm
+macx:LIBS += -framework Foundation -framework ApplicationServices -framework AppKit
+macx:DEFINES += MAC_OSX MSG_NOSIGNAL=0
+macx:ICON = src/qt/res/icons/Philosopherstone.icns
+macx:TARGET = "philosopherstone-qt"
+macx:QMAKE_CFLAGS_THREAD += -pthread
+macx:QMAKE_LFLAGS_THREAD += -pthread
+macx:QMAKE_CXXFLAGS_THREAD += -pthread
+
+# very likely unnessesary 
+QMAKE_LIBS_QT_ENTRY = -lssl $$OPENSSL_LIB_PATH
+
+# Set libraries and includes at end, to use platform-defined defaults if not overridden
+INCLUDEPATH += $$BOOST_INCLUDE_PATH $$BDB_INCLUDE_PATH $$OPENSSL_INCLUDE_PATH $$QRENCODE_INCLUDE_PATH
+# moved ssl-libs to beginning of file for customizing more easily and for OVERRIDING platform-defined defaults
+LIBS += $$join(BOOST_LIB_PATH,,-L,) $$join(BDB_LIB_PATH,,-L,) $$join(OPENSSL_LIB_PATH,,-L,) 
+LIBS += -lssl
+LIBS += $$join(QRENCODE_LIB_PATH,,-L,)
+LIBS += -lcrypto -ldb_cxx$$BDB_LIB_SUFFIX
+# -lgdi32 has to happen after -lcrypto (see  #681)
+windows:LIBS += -lws2_32 -lshlwapi -lmswsock -lole32 -loleaut32 -luuid -lgdi32
+LIBS += -lboost_system$$BOOST_LIB_SUFFIX -lboost_filesystem$$BOOST_LIB_SUFFIX -lboost_program_options$$BOOST_LIB_SUFFIX -lboost_thread$$BOOST_THREAD_LIB_SUFFIX
+windows:LIBS += -lboost_chrono$$BOOST_LIB_SUFFIX
+
+contains(RELEASE, 1) {
+    !windows:!macx {
+        # Linux: turn dynamic linking back on for c/c++ runtime libraries
+        LIBS += -Wl,-Bdynamic
+    }
+}
+
+!windows:!macx {
+    DEFINES += LINUX
+    LIBS += -lrt -ldl
+}
+
+system($$QMAKE_LRELEASE -silent $$_PRO_FILE_)

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -131,9 +131,12 @@ OBJS= \
     obj/pbkdf2.o \
     obj/scrypt_mine.o \
     obj/scrypt-x86.o \
-    obj/scrypt-x86_64.o
+    obj/scrypt-x86_64.o \
+ obj/scrypt-arm.o
 
 all: stoned
+# added new file "src/scrypt-arm.S"(obj/script-arm.o) of Diamond https://github.com/feldenthorne/Diamond/commit/01046753bf3e566d000854a41a2417493bd8db7c#diff-692b9d8596020ed1936d7f5af9508722
+
 
 LIBS += $(CURDIR)/leveldb/libleveldb.a $(CURDIR)/leveldb/libmemenv.a
 DEFS += $(addprefix -I,$(CURDIR)/leveldb/include)
@@ -157,6 +160,17 @@ obj/scrypt-x86.o: scrypt-x86.S
 
 obj/scrypt-x86_64.o: scrypt-x86_64.S
 	$(CXX) -c $(xCXXFLAGS) -MMD -o $@ $<
+
+
+
+
+#hinzugefuegt
+obj/scrypt-arm.o: scrypt-arm.S
+	$(CXX) -c $(xCXXFLAGS) -MMD -o $@ $<
+
+
+
+
 
 obj/%.o: %.cpp
 	$(CXX) -c $(xCXXFLAGS) -MMD -MF $(@:%.o=%.d) -o $@ $<

--- a/src/scrypt-arm.S
+++ b/src/scrypt-arm.S
@@ -1,0 +1,569 @@
+/*
+ * Copyright 2012 pooler@litecoinpool.org
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.  See COPYING for more details.
+ */
+
+#if defined(__arm__)
+
+#define __ARM_ARCH_5E_OR_6_OR_7__
+
+#ifdef __ARM_ARCH_5E_OR_6__
+
+.macro scrypt_shuffle
+	add	lr, r0, #9*4
+	ldmia	r0, {r2-r7}
+	ldmia	lr, {r2, r8-r12, lr}
+	str	r3, [r0, #5*4]
+	str	r5, [r0, #15*4]
+	str	r6, [r0, #12*4]
+	str	r7, [r0, #1*4]
+	ldr r5, [r0, #7*4]
+	str	r2, [r0, #13*4]
+	str	r8, [r0, #2*4]
+	strd	r4, [r0, #10*4]
+	str	r9, [r0, #7*4]
+	str	r10, [r0, #4*4]
+	str	r11, [r0, #9*4]
+	str	lr, [r0, #3*4]
+	
+	add	r2, r0, #64+0*4
+	add	lr, r0, #64+9*4
+	ldmia	r2, {r2-r7}
+	ldmia	lr, {r2, r8-r12, lr}
+	str	r3, [r0, #64+5*4]
+	str	r5, [r0, #64+15*4]
+	str	r6, [r0, #64+12*4]
+	str	r7, [r0, #64+1*4]
+	ldr r5, [r0, #64+7*4]
+	str	r2, [r0, #64+13*4]
+	str	r8, [r0, #64+2*4]
+	strd	r4, [r0, #64+10*4]
+	str	r9, [r0, #64+7*4]
+	str	r10, [r0, #64+4*4]
+	str	r11, [r0, #64+9*4]
+	str	lr, [r0, #64+3*4]
+.endm
+
+.macro salsa8_core_doubleround_body
+	add	r6, r2, r6
+	add	r7, r3, r7
+	eor	r10, r10, r6, ror #25
+	add	r6, r0, r4
+	eor	r11, r11, r7, ror #25
+	add	r7, r1, r5
+	strd	r10, [sp, #14*4]
+	eor	r12, r12, r6, ror #25
+	eor	lr, lr, r7, ror #25
+	
+	ldrd	r6, [sp, #10*4]
+	add	r2, r10, r2
+	add	r3, r11, r3
+	eor	r6, r6, r2, ror #23
+	add	r2, r12, r0
+	eor	r7, r7, r3, ror #23
+	add	r3, lr, r1
+	strd	r6, [sp, #10*4]
+	eor	r8, r8, r2, ror #23
+	eor	r9, r9, r3, ror #23
+	
+	ldrd	r2, [sp, #6*4]
+	add	r10, r6, r10
+	add	r11, r7, r11
+	eor	r2, r2, r10, ror #19
+	add	r10, r8, r12
+	eor	r3, r3, r11, ror #19
+	add	r11, r9, lr
+	eor	r4, r4, r10, ror #19
+	eor	r5, r5, r11, ror #19
+	
+	ldrd	r10, [sp, #2*4]
+	add	r6, r2, r6
+	add	r7, r3, r7
+	eor	r10, r10, r6, ror #14
+	add	r6, r4, r8
+	eor	r11, r11, r7, ror #14
+	add	r7, r5, r9
+	eor	r0, r0, r6, ror #14
+	eor	r1, r1, r7, ror #14
+	
+	
+	ldrd	r6, [sp, #14*4]
+	strd	r2, [sp, #6*4]
+	strd	r10, [sp, #2*4]
+	add	r6, r11, r6
+	add	r7, r0, r7
+	eor	r4, r4, r6, ror #25
+	add	r6, r1, r12
+	eor	r5, r5, r7, ror #25
+	add	r7, r10, lr
+	eor	r2, r2, r6, ror #25
+	eor	r3, r3, r7, ror #25
+	strd	r2, [sp, #6*4]
+	
+	add	r10, r3, r10
+	ldrd	r6, [sp, #10*4]
+	add	r11, r4, r11
+	eor	r8, r8, r10, ror #23
+	add	r10, r5, r0
+	eor	r9, r9, r11, ror #23
+	add	r11, r2, r1
+	eor	r6, r6, r10, ror #23
+	eor	r7, r7, r11, ror #23
+	strd	r6, [sp, #10*4]
+	
+	add	r2, r7, r2
+	ldrd	r10, [sp, #14*4]
+	add	r3, r8, r3
+	eor	r12, r12, r2, ror #19
+	add	r2, r9, r4
+	eor	lr, lr, r3, ror #19
+	add	r3, r6, r5
+	eor	r10, r10, r2, ror #19
+	eor	r11, r11, r3, ror #19
+	
+	ldrd	r2, [sp, #2*4]
+	add	r6, r11, r6
+	add	r7, r12, r7
+	eor	r0, r0, r6, ror #14
+	add	r6, lr, r8
+	eor	r1, r1, r7, ror #14
+	add	r7, r10, r9
+	eor	r2, r2, r6, ror #14
+	eor	r3, r3, r7, ror #14
+.endm
+
+.macro salsa8_core
+	ldmia	sp, {r0-r12, lr}
+	
+	ldrd	r10, [sp, #14*4]
+	salsa8_core_doubleround_body
+	ldrd	r6, [sp, #6*4]
+	strd	r2, [sp, #2*4]
+	strd	r10, [sp, #14*4]
+	salsa8_core_doubleround_body
+	ldrd	r6, [sp, #6*4]
+	strd	r2, [sp, #2*4]
+	strd	r10, [sp, #14*4]
+	salsa8_core_doubleround_body
+	ldrd	r6, [sp, #6*4]
+	strd	r2, [sp, #2*4]
+	strd	r10, [sp, #14*4]
+	salsa8_core_doubleround_body
+	
+	stmia	sp, {r0-r5}
+	strd	r8, [sp, #8*4]
+	str	r12, [sp, #12*4]
+	str	lr, [sp, #13*4]
+	strd	r10, [sp, #14*4]
+.endm
+
+#else
+
+.macro scrypt_shuffle
+.endm
+
+.macro salsa8_core_doubleround_body
+	ldr	r8, [sp, #8*4]
+	add	r11, r11, r10
+	ldr	lr, [sp, #13*4]
+	add	r12, r12, r3
+	eor	r2, r2, r11, ror #23
+	add	r11, r4, r0
+	eor	r7, r7, r12, ror #23
+	add	r12, r9, r5
+	str	r9, [sp, #9*4]
+	eor	r8, r8, r11, ror #23
+	str	r10, [sp, #14*4]
+	eor	lr, lr, r12, ror #23
+	
+	ldr	r11, [sp, #11*4]
+	add	r9, lr, r9
+	ldr	r12, [sp, #12*4]
+	add	r10, r2, r10
+	eor	r1, r1, r9, ror #19
+	add	r9, r7, r3
+	eor	r6, r6, r10, ror #19
+	add	r10, r8, r4
+	str	r8, [sp, #8*4]
+	eor	r11, r11, r9, ror #19
+	str	lr, [sp, #13*4]
+	eor	r12, r12, r10, ror #19
+	
+	ldr	r9, [sp, #10*4]
+	add	r8, r12, r8
+	ldr	r10, [sp, #15*4]
+	add	lr, r1, lr
+	eor	r0, r0, r8, ror #14
+	add	r8, r6, r2
+	eor	r5, r5, lr, ror #14
+	add	lr, r11, r7
+	eor	r9, r9, r8, ror #14
+	ldr	r8, [sp, #9*4]
+	eor	r10, r10, lr, ror #14
+	ldr	lr, [sp, #14*4]
+	
+	
+	add	r8, r9, r8
+	str	r9, [sp, #10*4]
+	add	lr, r10, lr
+	str	r10, [sp, #15*4]
+	eor	r11, r11, r8, ror #25
+	add	r8, r0, r3
+	eor	r12, r12, lr, ror #25
+	add	lr, r5, r4
+	eor	r1, r1, r8, ror #25
+	ldr	r8, [sp, #8*4]
+	eor	r6, r6, lr, ror #25
+	
+	add	r9, r11, r9
+	ldr	lr, [sp, #13*4]
+	add	r10, r12, r10
+	eor	r8, r8, r9, ror #23
+	add	r9, r1, r0
+	eor	lr, lr, r10, ror #23
+	add	r10, r6, r5
+	str	r11, [sp, #11*4]
+	eor	r2, r2, r9, ror #23
+	str	r12, [sp, #12*4]
+	eor	r7, r7, r10, ror #23
+	
+	ldr	r9, [sp, #9*4]
+	add	r11, r8, r11
+	ldr	r10, [sp, #14*4]
+	add	r12, lr, r12
+	eor	r9, r9, r11, ror #19
+	add	r11, r2, r1
+	eor	r10, r10, r12, ror #19
+	add	r12, r7, r6
+	str	r8, [sp, #8*4]
+	eor	r3, r3, r11, ror #19
+	str	lr, [sp, #13*4]
+	eor	r4, r4, r12, ror #19
+.endm
+
+.macro salsa8_core
+	ldmia	sp, {r0-r7}
+	
+	ldr	r12, [sp, #15*4]
+	ldr	r8, [sp, #11*4]
+	ldr	lr, [sp, #12*4]
+	
+	ldr	r9, [sp, #9*4]
+	add	r8, r8, r12
+	ldr	r11, [sp, #10*4]
+	add	lr, lr, r0
+	eor	r3, r3, r8, ror #25
+	add	r8, r5, r1
+	ldr	r10, [sp, #14*4]
+	eor	r4, r4, lr, ror #25
+	add	lr, r11, r6
+	eor	r9, r9, r8, ror #25
+	eor	r10, r10, lr, ror #25
+	
+	salsa8_core_doubleround_body
+	
+	ldr	r11, [sp, #10*4]
+	add	r8, r9, r8
+	ldr	r12, [sp, #15*4]
+	add	lr, r10, lr
+	eor	r11, r11, r8, ror #14
+	add	r8, r3, r2
+	eor	r12, r12, lr, ror #14
+	add	lr, r4, r7
+	eor	r0, r0, r8, ror #14
+	ldr	r8, [sp, #11*4]
+	eor	r5, r5, lr, ror #14
+	ldr	lr, [sp, #12*4]
+	
+	add	r8, r8, r12
+	str	r11, [sp, #10*4]
+	add	lr, lr, r0
+	str	r12, [sp, #15*4]
+	eor	r3, r3, r8, ror #25
+	add	r8, r5, r1
+	eor	r4, r4, lr, ror #25
+	add	lr, r11, r6
+	str	r9, [sp, #9*4]
+	eor	r9, r9, r8, ror #25
+	str	r10, [sp, #14*4]
+	eor	r10, r10, lr, ror #25
+	
+	salsa8_core_doubleround_body
+	
+	ldr	r11, [sp, #10*4]
+	add	r8, r9, r8
+	ldr	r12, [sp, #15*4]
+	add	lr, r10, lr
+	eor	r11, r11, r8, ror #14
+	add	r8, r3, r2
+	eor	r12, r12, lr, ror #14
+	add	lr, r4, r7
+	eor	r0, r0, r8, ror #14
+	ldr	r8, [sp, #11*4]
+	eor	r5, r5, lr, ror #14
+	ldr	lr, [sp, #12*4]
+	
+	add	r8, r8, r12
+	str	r11, [sp, #10*4]
+	add	lr, lr, r0
+	str	r12, [sp, #15*4]
+	eor	r3, r3, r8, ror #25
+	add	r8, r5, r1
+	eor	r4, r4, lr, ror #25
+	add	lr, r11, r6
+	str	r9, [sp, #9*4]
+	eor	r9, r9, r8, ror #25
+	str	r10, [sp, #14*4]
+	eor	r10, r10, lr, ror #25
+	
+	salsa8_core_doubleround_body
+	
+	ldr	r11, [sp, #10*4]
+	add	r8, r9, r8
+	ldr	r12, [sp, #15*4]
+	add	lr, r10, lr
+	eor	r11, r11, r8, ror #14
+	add	r8, r3, r2
+	eor	r12, r12, lr, ror #14
+	add	lr, r4, r7
+	eor	r0, r0, r8, ror #14
+	ldr	r8, [sp, #11*4]
+	eor	r5, r5, lr, ror #14
+	ldr	lr, [sp, #12*4]
+	
+	add	r8, r8, r12
+	str	r11, [sp, #10*4]
+	add	lr, lr, r0
+	str	r12, [sp, #15*4]
+	eor	r3, r3, r8, ror #25
+	add	r8, r5, r1
+	eor	r4, r4, lr, ror #25
+	add	lr, r11, r6
+	str	r9, [sp, #9*4]
+	eor	r9, r9, r8, ror #25
+	str	r10, [sp, #14*4]
+	eor	r10, r10, lr, ror #25
+	
+	salsa8_core_doubleround_body
+	
+	ldr	r11, [sp, #10*4]
+	add	r8, r9, r8
+	ldr	r12, [sp, #15*4]
+	add	lr, r10, lr
+	str	r9, [sp, #9*4]
+	eor	r11, r11, r8, ror #14
+	eor	r12, r12, lr, ror #14
+	add	r8, r3, r2
+	str	r10, [sp, #14*4]
+	add	lr, r4, r7
+	str	r11, [sp, #10*4]
+	eor	r0, r0, r8, ror #14
+	str	r12, [sp, #15*4]
+	eor	r5, r5, lr, ror #14
+	
+	stmia	sp, {r0-r7}
+.endm
+
+#endif
+
+
+.macro scrypt_core_macro1a_x4
+	ldmia	r0, {r4-r7}
+	ldmia	lr!, {r8-r11}
+	stmia	r1!, {r4-r7}
+	stmia	r3!, {r8-r11}
+	eor	r4, r4, r8
+	eor	r5, r5, r9
+	eor	r6, r6, r10
+	eor	r7, r7, r11
+	stmia	r0!, {r4-r7}
+	stmia	r12!, {r4-r7}
+.endm
+
+.macro scrypt_core_macro1b_x4
+	ldmia	r3!, {r8-r11}
+	ldmia	r2, {r4-r7}
+	eor	r8, r8, r4
+	eor	r9, r9, r5
+	eor	r10, r10, r6
+	eor	r11, r11, r7
+	ldmia	r0, {r4-r7}
+	stmia	r2!, {r8-r11}
+	eor	r4, r4, r8
+	eor	r5, r5, r9
+	eor	r6, r6, r10
+	eor	r7, r7, r11
+	ldmia	r1!, {r8-r11}
+	eor	r4, r4, r8
+	eor	r5, r5, r9
+	eor	r6, r6, r10
+	eor	r7, r7, r11
+	stmia	r0!, {r4-r7}
+	stmia	r12!, {r4-r7}
+.endm
+
+.macro scrypt_core_macro2_x4
+	ldmia	r12, {r4-r7}
+	ldmia	r0, {r8-r11}
+	add	r4, r4, r8
+	add	r5, r5, r9
+	add	r6, r6, r10
+	add	r7, r7, r11
+	stmia	r0!, {r4-r7}
+	ldmia	r2, {r8-r11}
+	eor	r4, r4, r8
+	eor	r5, r5, r9
+	eor	r6, r6, r10
+	eor	r7, r7, r11
+	stmia	r2!, {r4-r7}
+	stmia	r12!, {r4-r7}
+.endm
+
+.macro scrypt_core_macro3_x4
+	ldmia	r1!, {r4-r7}
+	ldmia	r0, {r8-r11}
+	add	r4, r4, r8
+	add	r5, r5, r9
+	add	r6, r6, r10
+	add	r7, r7, r11
+	stmia	r0!, {r4-r7}
+.endm
+
+.macro scrypt_core_macro3_x6
+	ldmia	r1!, {r2-r7}
+	ldmia	r0, {r8-r12, lr}
+	add	r2, r2, r8
+	add	r3, r3, r9
+	add	r4, r4, r10
+	add	r5, r5, r11
+	add	r6, r6, r12
+	add	r7, r7, lr
+	stmia	r0!, {r2-r7}
+.endm
+
+
+	.text
+	.code 32
+	.align 2
+	.globl scrypt_core
+	.globl _scrypt_core
+#ifdef __ELF__
+	.type scrypt_core, %function
+#endif
+scrypt_core:
+_scrypt_core:
+	stmfd	sp!, {r4-r11, lr}
+	mov	r12, sp
+	sub	sp, sp, #21*4
+	bic	sp, sp, #63
+	str	r12, [sp, #20*4]
+	
+	scrypt_shuffle
+	
+	str	r0, [sp, #16*4]
+	add	r12, r1, #1024*32*4
+	str	r12, [sp, #18*4]
+scrypt_core_loop1:
+	add	lr, r0, #16*4
+	add	r3, r1, #16*4
+	mov	r12, sp
+	scrypt_core_macro1a_x4
+	scrypt_core_macro1a_x4
+	scrypt_core_macro1a_x4
+	scrypt_core_macro1a_x4
+	str	r1, [sp, #17*4]
+	
+	salsa8_core
+	
+	ldr	r0, [sp, #16*4]
+	mov	r12, sp
+	add	r2, r0, #16*4
+	scrypt_core_macro2_x4
+	scrypt_core_macro2_x4
+	scrypt_core_macro2_x4
+	scrypt_core_macro2_x4
+	
+	salsa8_core
+	
+	ldr	r0, [sp, #16*4]
+	mov	r1, sp
+	add	r0, r0, #16*4
+	scrypt_core_macro3_x6
+	scrypt_core_macro3_x6
+	ldr	r3, [sp, #17*4]
+	ldr	r12, [sp, #18*4]
+	scrypt_core_macro3_x4
+	
+	add	r1, r3, #16*4
+	sub	r0, r0, #32*4
+	cmp	r1, r12
+	bne	scrypt_core_loop1
+	
+	ldr	r4, [r0, #16*4]
+	sub	r1, r1, #1024*32*4
+	str	r1, [sp, #17*4]
+	mov	r4, r4, lsl #32-10
+	mov	r12, #1024
+	add	r1, r1, r4, lsr #32-10-7
+scrypt_core_loop2:
+	add	r2, r0, #16*4
+	add	r3, r1, #16*4
+	str	r12, [sp, #18*4]
+	mov	r12, sp
+#ifdef __ARM_ARCH_5E_OR_6_OR_7__
+	pld [r1, #24*4]
+	pld [r1, #8*4]
+#endif
+	scrypt_core_macro1b_x4
+	scrypt_core_macro1b_x4
+	scrypt_core_macro1b_x4
+	scrypt_core_macro1b_x4
+	
+	salsa8_core
+	
+	ldr	r0, [sp, #16*4]
+	mov	r12, sp
+	add	r2, r0, #16*4
+	scrypt_core_macro2_x4
+	scrypt_core_macro2_x4
+	scrypt_core_macro2_x4
+	scrypt_core_macro2_x4
+	
+	salsa8_core
+	
+	ldr	r0, [sp, #16*4]
+	mov	r1, sp
+	ldr	r3, [sp, #17*4]
+	add	r0, r0, #16*4
+	scrypt_core_macro3_x4
+	mov	r4, r4, lsl #32-10
+	add	r3, r3, r4, lsr #32-10-7
+	str	r3, [sp, #19*4]
+#ifdef __ARM_ARCH_5E_OR_6_OR_7__
+	pld	[r3, #16*4]
+	pld	[r3]
+#endif
+	scrypt_core_macro3_x6
+	scrypt_core_macro3_x6
+	
+	ldr	r12, [sp, #18*4]
+	sub	r0, r0, #32*4
+	ldr	r1, [sp, #19*4]
+	subs	r12, r12, #1
+	bne	scrypt_core_loop2
+	
+	scrypt_shuffle
+	
+	ldr	sp, [sp, #20*4]
+#ifdef __thumb__
+	ldmfd	sp!, {r4-r11, lr}
+	bx	lr
+#else
+	ldmfd	sp!, {r4-r11, pc}
+#endif
+
+#endif

--- a/src/scrypt_mine.cpp
+++ b/src/scrypt_mine.cpp
@@ -1,35 +1,44 @@
-/*-
-* Copyright 2009 Colin Percival, 2011 ArtForz, 2011 pooler, 2013 Balthazar
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions
-* are met:
-* 1. Redistributions of source code must retain the above copyright
-* notice, this list of conditions and the following disclaimer.
-* 2. Redistributions in binary form must reproduce the above copyright
-* notice, this list of conditions and the following disclaimer in the
-* documentation and/or other materials provided with the distribution.
-*
-* THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-* OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-* SUCH DAMAGE.
-*
-* This file was originally written by Colin Percival as part of the Tarsnap
-* online backup system.
-*/
+/*- complete file is form here (added ARM/raspi comaptibility): https://github.com/feldenthorne/Diamond/commit/01046753bf3e566d000854a41a2417493bd8db7c#diff-692b9d8596020ed1936d7f5af9508722
+ * Copyright 2009 Colin Percival, 2011 ArtForz, 2011 pooler, 2013 Balthazar
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file was originally written by Colin Percival as part of the Tarsnap
+ * online backup system.
+ */
 
 #include <stdlib.h>
 #include <stdint.h>
+
+// Here, we need to check if we're compiling for an ARM processor. If we are, we
+// need to make sure we don't try to use SSE instructions
+extern "C" {
+#ifndef NOSSE
+#ifndef NO_ASM
 #include <xmmintrin.h>
+#endif
+#endif
+}
 
 #include "scrypt_mine.h"
 #include "pbkdf2.h"
@@ -37,9 +46,38 @@
 #include "util.h"
 #include "net.h"
 
-#if defined (__x86_64__) || defined (__i386__)
-#define SCRYPT_BUFFER_SIZE (131072 + 63)
+extern bool fShutdown;
+extern bool fGenerateBitcoins;
+
+extern CBlockIndex* pindexBest;
+extern uint32_t nTransactionsUpdated;
+
+// Here, we need to check to see what type of processor we're using
+// because x86 and x64 have different buffer size requirements.
+// We're assuming ARM processors fall in with i386 processors
+// because I can't think of a good reason to automatically go with a
+// larger buffer, given the lower RAM and swap file sizes for ARM boards 
+// compared to x86 boards.
+// In case this is an issue, see the following URL for help determining
+// a good buffer size:
+// https://github.com/pooler/cpuminer/blob/4611186cb88eec76f22a88565675473b2eeade28/scrypt.c#L502-510
+// It basically recommends SCRYPT_BUFFER_SIZE = (sizeof(int) * SCRYPT_MAX_WAYS * 128 + 63)
+#if defined(__x86_64__)
+
+#define SCRYPT_3WAY
+#define SCRYPT_BUFFER_SIZE (3 * 131072 + 63)
+
+extern "C" int scrypt_best_throughput();
 extern "C" void scrypt_core(uint32_t *X, uint32_t *V);
+extern "C" void scrypt_core_2way(uint32_t *X, uint32_t *Y, uint32_t *V);
+extern "C" void scrypt_core_3way(uint32_t *X, uint32_t *Y, uint32_t *Z, uint32_t *V);
+
+#elif ( defined(__i386__)||defined(__arm__) )
+
+#define SCRYPT_BUFFER_SIZE (131072 + 63)
+
+extern  "C" void scrypt_core(uint32_t *X, uint32_t *V);
+
 #endif
 
 void *scrypt_buffer_alloc() {
@@ -52,9 +90,9 @@ void scrypt_buffer_free(void *scratchpad)
 }
 
 /* cpu and memory intensive function to transform a 80 byte buffer into a 32 byte output
-scratchpad size needs to be at least 63 + (128 * r * p) + (256 * r + 64) + (128 * r * N) bytes
-r = 1, p = 1, N = 1024
-*/
+   scratchpad size needs to be at least 63 + (128 * r * p) + (256 * r + 64) + (128 * r * N) bytes
+   r = 1, p = 1, N = 1024
+ */
 
 static void scrypt(const void* input, size_t inputlen, uint32_t *res, void *scratchpad)
 {
@@ -72,4 +110,117 @@ static void scrypt(const void* input, size_t inputlen, uint32_t *res, void *scra
 void scrypt_hash(const void* input, size_t inputlen, uint32_t *res, void *scratchpad)
 {
     return scrypt(input, inputlen, res, scratchpad);
+}
+
+#ifdef SCRYPT_3WAY
+static void scrypt_2way(const void *input1, const void *input2, size_t input1len, size_t input2len, uint32_t *res1, uint32_t *res2, void *scratchpad)
+{
+    uint32_t *V;
+    uint32_t X[32], Y[32];
+    V = (uint32_t *)(((uintptr_t)(scratchpad) + 63) & ~ (uintptr_t)(63));
+
+    PBKDF2_SHA256((const uint8_t*)input1, input1len, (const uint8_t*)input1, input1len, 1, (uint8_t *)X, 128);
+    PBKDF2_SHA256((const uint8_t*)input2, input2len, (const uint8_t*)input2, input2len, 1, (uint8_t *)Y, 128);
+
+    scrypt_core_2way(X, Y, V);
+
+    PBKDF2_SHA256((const uint8_t*)input1, input1len, (uint8_t *)X, 128, 1, (uint8_t*)res1, 32);
+    PBKDF2_SHA256((const uint8_t*)input2, input2len, (uint8_t *)Y, 128, 1, (uint8_t*)res2, 32);
+}
+
+static void scrypt_3way(const void *input1, const void *input2, const void *input3,
+   size_t input1len, size_t input2len, size_t input3len, uint32_t *res1, uint32_t *res2, uint32_t *res3,
+   void *scratchpad)
+{
+    uint32_t *V;
+    uint32_t X[32], Y[32], Z[32];
+    V = (uint32_t *)(((uintptr_t)(scratchpad) + 63) & ~ (uintptr_t)(63));
+
+    PBKDF2_SHA256((const uint8_t*)input1, input1len, (const uint8_t*)input1, input1len, 1, (uint8_t *)X, 128);
+    PBKDF2_SHA256((const uint8_t*)input2, input2len, (const uint8_t*)input2, input2len, 1, (uint8_t *)Y, 128);
+    PBKDF2_SHA256((const uint8_t*)input3, input3len, (const uint8_t*)input3, input3len, 1, (uint8_t *)Z, 128);
+
+    scrypt_core_3way(X, Y, Z, V);
+
+    PBKDF2_SHA256((const uint8_t*)input1, input1len, (uint8_t *)X, 128, 1, (uint8_t*)res1, 32);
+    PBKDF2_SHA256((const uint8_t*)input2, input2len, (uint8_t *)Y, 128, 1, (uint8_t*)res2, 32);
+    PBKDF2_SHA256((const uint8_t*)input3, input3len, (uint8_t *)Z, 128, 1, (uint8_t*)res3, 32);
+}
+#endif
+
+unsigned int scanhash_scrypt(block_header *pdata, void *scratchbuf,
+    uint32_t max_nonce, uint32_t &hash_count,
+    void *result, block_header *res_header)
+{
+    hash_count = 0;
+    block_header data = *pdata;
+    uint32_t hash[8];
+    unsigned char *hashc = (unsigned char *) &hash;
+
+#ifdef SCRYPT_3WAY
+    block_header data2 = *pdata;
+    uint32_t hash2[8];
+    unsigned char *hashc2 = (unsigned char *) &hash2;
+
+    block_header data3 = *pdata;
+    uint32_t hash3[8];
+    unsigned char *hashc3 = (unsigned char *) &hash3;
+
+    int throughput = scrypt_best_throughput();
+#endif
+
+    uint32_t n = 0;
+
+    while (true) {
+
+        data.nonce = n++;
+
+#ifdef SCRYPT_3WAY
+        if (throughput >= 2 && n < max_nonce) {
+            data2.nonce = n++;
+            if(throughput >= 3)
+            {
+                data3.nonce = n++;
+                scrypt_3way(&data, &data2, &data3, 80, 80, 80, hash, hash2, hash3, scratchbuf);
+                hash_count += 3;
+
+                if (hashc3[31] == 0 && hashc3[30] == 0) {
+                    memcpy(result, hash3, 32);
+                    *res_header = data3;
+
+                    return data3.nonce;
+                }
+            }
+            else
+            {
+                scrypt_2way(&data, &data2, 80, 80, hash, hash2, scratchbuf);
+                hash_count += 2;
+            }
+
+            if (hashc2[31] == 0 && hashc2[30] == 0) {
+                memcpy(result, hash2, 32);
+
+                return data2.nonce;
+            }
+        } else {
+            scrypt(&data, 80, hash, scratchbuf);
+            hash_count += 1;
+        }
+#else
+        scrypt(&data, 80, hash, scratchbuf);
+        hash_count += 1;
+#endif
+        if (hashc[31] == 0 && hashc[30] == 0) {
+            memcpy(result, hash, 32);
+
+            return data.nonce;
+        }
+
+        if (n >= max_nonce) {
+            hash_count = 0xffff + 1;
+            break;
+        }
+    }
+
+    return (unsigned int) -1;
 }


### PR DESCRIPTION
@VladK75 
I manually merged the changes of this Diamond commit: 
https://github.com/feldenthorne/Diamond/commit/01046753bf3e566d000854a41a2417493bd8db7c#diff-692b9d8596020ed1936d7f5af9508722
 into your base fork.
The problem is that the original "scrypt_mine.cpp" file needs SSE2 (#include <xmmintrin.h>). Now it will be tested indirectly if the cpu has SSE2 or not in the modified "scrypt_mine.cpp" file.
The additional *.pro files should work on windows and linux i686, too but I have not tested it.

By the way the dependency on the old openssl versions could be solved with this commit: 
https://github.com/bitcoin/bitcoin/commit/4ec3561eb3473638230ef780b41343bc6284b460